### PR TITLE
Fixed wrong translations of "share" in german

### DIFF
--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -6,7 +6,7 @@
   "No files added yet": "Noch keine Dateien hinzugefügt",
   "No recipients": "Keine Empfänger",
   "Powered by": "Powered by",
-  "Reverse Share": "Umgekehrte Aktie",
+  "Reverse Share": "Umgekehrte Freigabe",
   "Share Name": "Name der Freigabe",
   "Share URL": "URL teilen",
   "We'll provide you with a link instead": {
@@ -227,7 +227,7 @@
       "allow_chunked_uploads_description": "Der Chunked-Upload-Modus unterteilt Dateien in kleinere Segmente, die nacheinander übertragen werden. Diese Methode ist zwar bei kleineren Dateien etwas langsamer als der direkte Upload, bietet aber bei der Übertragung großer Dateien mehr Stabilität und Zuverlässigkeit. Chunked Uploads unterstützen die Verfolgung des Fortschritts und ermöglichen es dem Benutzer, die Übertragung manuell anzuhalten und fortzusetzen. Dies ist ideal für Dateien über 100 MB oder bei instabilen Netzwerkverbindungen.",
       "allow_direct_uploads": "Direkten Upload-Modus zulassen",
       "allow_direct_uploads_description": "Beim direkten Upload werden die Dateien in einer einzigen, ununterbrochenen Anfrage übertragen. Während diese Methode für die meisten Dateien die schnellsten Übertragungsgeschwindigkeiten bietet, kann es bei extrem großen Dateien zu Stabilitätsproblemen oder Timeouts kommen. Für eine optimale Leistung bei Dateien, die größer als 100 MB sind, ist der Upload in Teilen die bessere Option.",
-      "allow_reverse_shares": "Umgekehrte Aktien zulassen",
+      "allow_reverse_shares": "Umgekehrte Freigaben zulassen",
       "allow_reverse_shares_description": "Legt fest, ob Ihre registrierten Benutzer die Erlaubnis haben sollen, umgekehrte Freigabeanforderungen zu senden. Diese Anfragen geben externen Personen einen einmaligen Upload-Pass, der es ihnen ermöglicht, Dateien direkt an den registrierten Benutzer zu liefern, der die Anfrage initiiert hat.\n\n\n\n\n",
       "application_name": "Name der Anwendung",
       "application_name_description": "Passen Sie den angezeigten Namen Ihrer Anwendung an, der in Titelleisten, Dialogfeldern und anderen Oberflächenelementen erscheint. Dies trägt dazu bei, ein konsistentes Branding in der gesamten Benutzerumgebung zu erhalten.",
@@ -284,7 +284,7 @@
       "max_share_size_description": "Legen Sie die maximale Größe von geteilten Dateien fest, die ein Benutzer erstellen kann. Der Wert wird in Megabyte oder Gigabyte angegeben.",
       "provider_trust_warning": "Warnung: Vertrauen in Auth Provider ",
       "provider_trust_warning_description": "Stellen Sie sicher, dass Sie nur Authentifizierungsanbieter konfigurieren und aktivieren, denen Sie vertrauen. Authentifizierungsanbieter verfügen über erweiterte Zugriffsrechte auf Ihre Anwendungs- und Benutzerdaten. Das Hinzufügen von nicht vertrauenswürdigen oder gefährdeten Anbietern kann zu unbefugtem Zugriff, Datenverletzungen oder Kontoübernahmen führen.",
-      "reverse_shares": "Reverse-Aktien",
+      "reverse_shares": "Umgekehrte Freigaben",
       "select_auth_provider": "Wählen Sie einen Autorisierungsanbieter",
       "share_deleted_emails": "E-Mails bei gelöschten Dateien",
       "share_deleted_emails_description": "Benachrichtigung der Benutzer, wenn ihre Freigaben endgültig aus dem System gelöscht wurden. Dies bestätigt den Abschluss des Lebenszyklus von Inhalten aus Sicherheits- und Compliance-Gründen.",
@@ -426,7 +426,7 @@
       "count": "{value, plural, one {{count} Datei} other {{count} Dateien}}",
       "including": "einschließlich:"
     },
-    "not_found": "Die von Ihnen gesuchte Aktie wurde nicht gefunden. Möglicherweise müssen Sie sich anmelden, um sie zu sehen.",
+    "not_found": "Die von Ihnen gesuchte Freigabe wurde nicht gefunden. Möglicherweise müssen Sie sich anmelden, um sie zu sehen.",
     "passwordNotProtected": "Öffnen Sie",
     "passwordProtected": "Passwort geschützt"
   },
@@ -440,7 +440,7 @@
       "chunked": "Chunked-Upload-Modus",
       "direct": "Direkter Upload-Modus"
     },
-    "expiry_label": "Die Aktie verfällt am {value} {unit} (Änderung)",
+    "expiry_label": "Die Freigabe verfällt am {value} {unit} (Änderung)",
     "expiry_max_value": "Max: {value}",
     "expiry_too_long": "Die von Ihnen eingegebene Verfallszeit überschreitet die Höchstgrenze. Wir haben sie automatisch auf den längsten zulässigen Zeitraum angepasst.",
     "expiry_unit": {


### PR DESCRIPTION
Several occurrences of the word “Aktie” (wrong translation of “share”) in the German language file have been replaced.