### PR TITLE
fix send reverse share to existing user

### DIFF
--- a/app/Http/Controllers/ReverseSharesController.php
+++ b/app/Http/Controllers/ReverseSharesController.php
@@ -63,10 +63,10 @@ class ReverseSharesController extends Controller
                 'password' => Hash::make(Str::random(20)), //set a random password so the user can't login
                 'is_guest' => true
             ]);
-
-            $token = $token = auth()->tokenById($guestUser->id);
-            $encryptedToken = Crypt::encryptString($token);
         }
+
+        $token = $token = auth()->tokenById($guestUser->id);
+        $encryptedToken = Crypt::encryptString($token);
 
         $invite = ReverseShareInvite::create([
             'user_id' => $user->id,


### PR DESCRIPTION
Fix send a reverse share request to a existing user.
(token was not created when a user with that email address already exists.)

Fixes 
#136 
#95 