### PR TITLE
Add download limit feature to shares and update related UI components

### DIFF
--- a/app/Http/Controllers/SharesController.php
+++ b/app/Http/Controllers/SharesController.php
@@ -687,6 +687,12 @@ class SharesController extends Controller
     }
 
     $share->download_count++;
+    
+    // Auto-expire if download limit is reached
+    if ($share->download_limit != null && $share->download_count >= $share->download_limit) {
+      $share->expires_at = \Carbon\Carbon::now();
+    }
+    
     $share->save();
     return $download;
   }

--- a/app/Http/Controllers/UploadsController.php
+++ b/app/Http/Controllers/UploadsController.php
@@ -81,7 +81,8 @@ class UploadsController extends Controller
       'description' => ['max:500'],
       'uploadIds' => ['required', 'array'],
       'uploadIds.*' => ['required', 'string'],
-      'expiry_date' => ['required', 'date']
+      'expiry_date' => ['required', 'date'],
+      'download_limit' => ['nullable', 'integer', 'min:1']
     ]);
 
     if ($validator->fails()) {
@@ -231,6 +232,7 @@ class UploadsController extends Controller
       'name' => $request->name,
       'description' => $request->description,
       'expires_at' => $expiryDate,
+      'download_limit' => $request->download_limit,
       'user_id' => $user->id,
       'path' => $sharePath,
       'long_id' => $longId,

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -116,6 +116,7 @@ const uploadBundledFiles = async (
   shareDescription,
   recipients,
   expiryDate,
+  downloadLimit,
   password,
   passwordConfirm,
   onProgress,
@@ -200,6 +201,8 @@ const uploadBundledFiles = async (
     })
 
     const apiUrl = getApiUrl()
+    const downloadLimitValue = downloadLimit ? parseInt(downloadLimit) : null
+    
     const response = await fetchWithAuth(`${apiUrl}/api/uploads/create-share-from-uploads`, {
       method: 'POST',
       headers: {
@@ -215,6 +218,7 @@ const uploadBundledFiles = async (
         uploadIds: [uploadResult.uploadId],
         filePaths: {}, // Not needed for bundles, paths are in the manifest
         expiry_date: expiryDate,
+        download_limit: downloadLimitValue,
         password: password,
         password_confirm: passwordConfirm,
         isBundle: true
@@ -1530,6 +1534,7 @@ export const uploadFilesInChunks = async (
   shareDescription,
   recipients,
   expiryDate,
+  downloadLimit,
   password,
   passwordConfirm,
   onProgress,
@@ -1547,6 +1552,7 @@ export const uploadFilesInChunks = async (
       shareDescription,
       recipients,
       expiryDate,
+      downloadLimit,
       password,
       passwordConfirm,
       onProgress,
@@ -1665,6 +1671,7 @@ export const uploadFilesInChunks = async (
   const uploadIds = results.map((r) => r.uploadId)
   const maxRetries = 5
   const baseDelayMs = 500
+  const downloadLimitValue = downloadLimit ? parseInt(downloadLimit) : null
   
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     try {
@@ -1683,6 +1690,7 @@ export const uploadFilesInChunks = async (
           uploadIds: uploadIds,
           filePaths: filePaths,
           expiry_date: expiryDate,
+          download_limit: downloadLimitValue,
           password: password,
           password_confirm: passwordConfirm
         })

--- a/resources/js/components/downloader.vue
+++ b/resources/js/components/downloader.vue
@@ -165,13 +165,18 @@ const filesByDirectory = computed(() => {
         </div>
       </div>
       <div class="share-expires">
-        {{
-          $t('share.expires.in', {
-            days: timeUntilExpiration(share.expires_at).days,
-            hours: timeUntilExpiration(share.expires_at).hours,
-            minutes: timeUntilExpiration(share.expires_at).minutes
-          })
-        }}
+        <div>
+          {{
+            $t('share.expires.in', {
+              days: timeUntilExpiration(share.expires_at).days,
+              hours: timeUntilExpiration(share.expires_at).hours,
+              minutes: timeUntilExpiration(share.expires_at).minutes
+            })
+          }}
+        </div>
+        <div v-if="share.download_limit" class="download-limit">
+          {{ $t('share.download_limit_info', 'Downloaded {count} of {limit} times', { count: share.download_count, limit: share.download_limit }) }}
+        </div>
       </div>
       <div class="share-files-list">
         <directory-item
@@ -342,7 +347,9 @@ const filesByDirectory = computed(() => {
   background: var(--panel-item-background-color);
   padding: 10px 20px;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
   margin-top: 0!important;
 }
 </style>

--- a/resources/js/components/uploader.vue
+++ b/resources/js/components/uploader.vue
@@ -5,6 +5,7 @@ import {
   FilePlus,
   FolderPlus,
   Upload,
+  Download,
   Trash,
   Copy,
   X,
@@ -89,6 +90,13 @@ const timeRemaining = computed(() => {
 const expiryValue = ref(domData().default_expiry_time)
 const expiryUnit = ref('days')
 const maxExpiryTime = ref(domData().max_expiry_time)
+
+const downloadLimit = ref(null)
+const showDownloadLimitSettings = ref(false)
+const toggleDownloadLimitSettings = () => {
+  showDownloadLimitSettings.value = !showDownloadLimitSettings.value
+}
+
 const errors = ref({
   shareName: null
 })
@@ -414,6 +422,7 @@ const doTusUpload = async (uploadId) => {
       shareDescription.value,
       recipients.value,
       calculateExpiryDate(),
+      downloadLimit.value,
       sharePassword.value,
       sharePasswordConfirm.value,
       (progress) => {
@@ -872,6 +881,21 @@ const filesByDirectory = computed(() => {
         <option value="months" v-if="canExpireInMonths">{{ $t('uploader.expiry_unit.months') }}</option>
         <option value="years" v-if="canExpireInYears">{{ $t('uploader.expiry_unit.years') }}</option>
       </select>
+    </div>
+  </div>
+  <div class="expiry-settings-container">
+    <span class="expiry-label" @click="toggleDownloadLimitSettings">
+      <Download />
+      {{ $t('uploader.download_limit_label', { value: downloadLimit || $t('uploader.download_limit_unlimited') }) }}
+    </span>
+    <div class="expiry-settings" :class="{ visible: showDownloadLimitSettings }">
+      <input 
+        type="number" 
+        v-model="downloadLimit" 
+        class="w-full" 
+        min="1" 
+        :placeholder="$t('uploader.download_limit_unlimited')" 
+      />
     </div>
   </div>
   <div class="upload-basket-details pt-2">

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -978,6 +978,7 @@
       "password_required": "Sie müssen das Passwort eingeben, um diese Freigabe herunterzuladen.",
       "password_required_short": "Passwort eingeben"
     },
+    "download_limit_info": "Bereits {count} von {limit} Mal heruntergeladen",
     "download_limit_reached": "Download-Grenze erreicht",
     "download_limit_reached.message": "Die Freigabe, die Sie herunterladen möchten, hat ihr Download-Limit erreicht. Bitten Sie den Ersteller der Freigabe, das Download-Limit zu erhöhen.",
     "expired": "Freigabe abgelaufen",
@@ -1002,6 +1003,8 @@
       "chunked": "Chunked-Loading-Modus",
       "direct": "Direkter Upload-Modus"
     },
+    "download_limit_label": "Download-Limit: {value} (Änderung)",
+    "download_limit_unlimited": "Unbegrenzt",
     "expiry_label": "Die Aktie verfällt am {value} {unit} (Änderung)",
     "expiry_max_value": "Max: {value}",
     "expiry_too_long": "Die von Ihnen eingegebene Verfallszeit überschreitet die Höchstgrenze. Wir haben sie automatisch auf den längsten zulässigen Zeitraum angepasst.",

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -999,6 +999,7 @@
       "password_required": "You must enter the password to download this share.",
       "password_required_short": "Enter password"
     },
+    "download_limit_info": "Downloaded {count} of {limit} times",
     "download_limit_reached": "Download Limit Reached",
     "download_limit_reached.message": "The share you are trying to download has reached its download limit. Please ask the share creator to increase the download limit.",
     "expired": "Share Expired",
@@ -1023,7 +1024,9 @@
       "chunked": "Chunked upload mode",
       "direct": "Direct upload mode"
     },
-    "expiry_label": "Share will expire in {value} {unit}  (change)",
+    "download_limit_label": "Download limit: {value} (change)",
+    "download_limit_unlimited": "Unlimited",
+    "expiry_label": "Share will expire in {value} {unit} (change)",
     "expiry_max_value": "Max: {value}",
     "expiry_too_long": "The expiry time you entered exceeds the maximum limit. We've automatically adjusted it to the longest period allowed.",
     "expiry_unit": {

--- a/resources/js/i18n/fr.json
+++ b/resources/js/i18n/fr.json
@@ -978,6 +978,7 @@
       "password_required": "Vous devez saisir le mot de passe pour télécharger ce partage.",
       "password_required_short": "Entrez le mot de passe"
     },
+    "download_limit_info": "Téléchargé {count} fois sur {limit}",
     "download_limit_reached": "Limite de téléchargement atteinte",
     "download_limit_reached.message": "Le partage que vous essayez de télécharger a atteint sa limite de téléchargement. Veuillez demander au créateur du partage d'augmenter la limite de téléchargement.",
     "expired": "Partage expiré",
@@ -1002,6 +1003,8 @@
       "chunked": "Mode de téléchargement par morceaux",
       "direct": "Mode de téléchargement direct"
     },
+    "download_limit_label": "Limite de téléchargement: {value} (modifier)",
+    "download_limit_unlimited": "Illimité",
     "expiry_label": "Le partage expirera dans {value} {unit}  (modifier)",
     "expiry_max_value": "Max {value}",
     "expiry_too_long": "Le délai d'expiration que vous avez introduit dépasse la limite maximale. Nous l'avons automatiquement adapté à la période la plus longue autorisée.",

--- a/resources/js/i18n/it.json
+++ b/resources/js/i18n/it.json
@@ -978,6 +978,7 @@
       "password_required": "Per scaricare questa condivisione è necessario inserire la password.",
       "password_required_short": "Inserire la password"
     },
+    "download_limit_info": "Scaricato {count} su {limit} volte",
     "download_limit_reached": "Scarica il limite raggiunto",
     "download_limit_reached.message": "La condivisione che si sta cercando di scaricare ha raggiunto il limite di download. Chiedere al creatore della condivisione di aumentare il limite di download.",
     "expired": "Quota scaduta",
@@ -1002,6 +1003,8 @@
       "chunked": "Modalità di caricamento chunked",
       "direct": "Modalità di caricamento diretto"
     },
+    "download_limit_label": "Limite di download: {value} (modifica)",
+    "download_limit_unlimited": "Illimitato",
     "expiry_label": "L'azione scadrà nel {value} {unit} (modifica)",
     "expiry_max_value": "Max: {value}",
     "expiry_too_long": "Il tempo di scadenza inserito supera il limite massimo. L'abbiamo adattato automaticamente al periodo più lungo consentito.",

--- a/resources/js/i18n/nl.json
+++ b/resources/js/i18n/nl.json
@@ -978,6 +978,7 @@
       "password_required": "Je moet het wachtwoord invoeren om deze share te downloaden.",
       "password_required_short": "Wachtwoord invoeren"
     },
+    "download_limit_info": "{count} van {limit} keer gedownload",
     "download_limit_reached": "Download limiet bereikt",
     "download_limit_reached.message": "De share die je probeert te downloaden heeft zijn downloadlimiet bereikt. Vraag de maker van de share om de downloadlimiet te verhogen.",
     "expired": "Link verlopen",
@@ -1002,6 +1003,8 @@
       "chunked": "Modus voor gebundeld laden",
       "direct": "Directe uploadmodus"
     },
+    "download_limit_label": "Downloadlimiet: {value} (verandering)",
+    "download_limit_unlimited": "Onbeperkt",
     "expiry_label": "Aandeel vervalt in {value} {unit} (verandering)",
     "expiry_max_value": "Max: {value}",
     "expiry_too_long": "De vervaltijd die je hebt opgegeven overschrijdt de maximumlimiet. We hebben het automatisch aangepast naar de langst toegestane periode.",

--- a/resources/js/i18n/pt.json
+++ b/resources/js/i18n/pt.json
@@ -949,6 +949,7 @@
       "password_required": "É necessário introduzir a palavra-passe para descarregar esta partilha.",
       "password_required_short": "Introduzir a palavra-passe"
     },
+    "download_limit_info": "Descarregado {count} de {limit} vezes",
     "download_limit_reached": "Limite de Descarregamentos Atingido",
     "download_limit_reached.message": "A partilha que está a tentar descarregar atingiu o limite de descarregamentos. Por favor peça ao criador da partilha que aumente o limite.",
     "expired": "Partilha Expirada",
@@ -973,6 +974,8 @@
       "chunked": "Modo de carregamento por blocos",
       "direct": "Modo de carregamento direto"
     },
+    "download_limit_label": "Limite de descarregamentos: {value} (alteração)",
+    "download_limit_unlimited": "Ilimitado",
     "expiry_label": "A ação expirará em {value} {unit} (alteração)",
     "expiry_max_value": "Máximo: {value}",
     "expiry_too_long": "O tempo de expiração que introduziu excede o limite máximo. Ajustámo-lo automaticamente para o período mais longo permitido.",


### PR DESCRIPTION
This PR introduces the missing functionality to set a maximum download limit when creating file shares, making it work seamlessly alongside the existing time based expiration feature.

Changes:

- Uploader UI: Added a numeric input to the share creation panel allowing users to set a specific download limit (defaults to "Unlimited").
- Downloader UI: Added a live tracker below the expiration timer showing remaining downloads (e.g., "Downloaded 1 of 3 times").
- Enforcement: SharesController.php now blocks access and automatically sets the share's expires_at to Carbon::now() the moment the limit is hit.
- Cleanup: By forcing the expiration date, this feature natively hooks into the existing cleanExpiredShares job to physically delete the files without needing new cleanup logic.
- Translations: Added localization strings across 6 languages for the new UI elements.

Testing:
Create a share with a set download limit. Download it until the limit is exhausted; the share should immediately invalidate and reflect as expired.
