### PR TITLE
fix: guest invite links expire after 60 min due to JWT TTL mismatch

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -14,7 +14,6 @@ use App\Mail\passwordResetMail;
 use App\Jobs\sendEmail;
 use Illuminate\Auth\Events\PasswordReset;
 use App\Models\ReverseShareInvite;
-use Illuminate\Support\Facades\Crypt;
 
 
 class AuthController extends Controller
@@ -101,18 +100,12 @@ class AuthController extends Controller
             ], 422);
         }
 
-        $token = Crypt::decryptString($request->token);
-
-        $user = Auth::setToken($token)->user();
-
-        if (!$user) {
-            return response()->json([
-                'status' => 'error',
-                'message' => 'Unauthorized'
-            ], 401);
-        }
-
-        $invite = ReverseShareInvite::where('guest_user_id', $user->id)->first();
+        // Look up the invite by the SHA-256 hash of the plain-text token.
+        // This replaces the old approach of decoding a JWT embedded in the link,
+        // which broke after 60 minutes because the JWT TTL is shorter than the
+        // 7-day invite expiry.
+        $invite = ReverseShareInvite::where('guest_token', hash('sha256', $request->token))
+            ->first();
 
         if (!$invite) {
             return response()->json([
@@ -135,10 +128,16 @@ class AuthController extends Controller
             ], 404);
         }
 
-        $invite->markAsUsed();
+        $user = User::find($invite->guest_user_id);
 
-        //invalidate the token
-        auth()->invalidate();
+        if (!$user) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Guest user not found'
+            ], 404);
+        }
+
+        $invite->markAsUsed();
 
         return $this->respondWithToken($user);
     }

--- a/app/Http/Controllers/ReverseSharesController.php
+++ b/app/Http/Controllers/ReverseSharesController.php
@@ -9,7 +9,6 @@ use App\Models\User;
 use App\Models\ReverseShareInvite;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Crypt;
 use App\Jobs\sendEmail;
 use App\Mail\reverseShareInviteMail;
 use App\Models\Setting;
@@ -62,31 +61,38 @@ class ReverseSharesController extends Controller
             })
             ->first();
 
-        $encryptedToken = null;
+        $plainToken = null;
         $guestUserId = null;
 
         if ($existingUser) {
-            // Existing user - no token, no guest user
-            // They will need to log in with their credentials
-            $guestUserId = null;
+            // Existing user — no guest account, no token.
+            // The invite link will contain invite_id instead; the recipient
+            // must log in with their own credentials to accept it.
         } else {
-            // Create a guest user for the invite
+            // New (guest) user — create a throw-away account with a random
+            // password that nobody knows, so the only way in is via the link.
             $guestUser = User::create([
                 'name' => $request->recipient_name,
-                'email' => Str::random(20), //we don't need a real email for the guest user
-                'password' => Hash::make(Str::random(20)), //set a random password so the user can't login
+                'email' => Str::random(20), // not a real address; never used for auth
+                'password' => Hash::make(Str::random(32)),
                 'is_guest' => true
             ]);
             $guestUserId = $guestUser->id;
 
-            // Generate a token only for guest users
-            $token = auth()->tokenById($guestUser->id);
-            $encryptedToken = Crypt::encryptString($token);
+            // Generate a cryptographically secure random token.
+            // Only the SHA-256 hash is stored in the database; the plain-text
+            // token is placed in the invite link and never persisted, so even a
+            // full DB dump does not let an attacker accept the invite.
+            // The token's validity is governed by invite.expires_at (7 days),
+            // not by a JWT TTL, which fixes the "link expires after 60 minutes"
+            // bug present in the previous JWT-based approach.
+            $plainToken = Str::random(64);
         }
 
         $invite = ReverseShareInvite::create([
             'user_id' => $user->id,
             'guest_user_id' => $guestUserId,
+            'guest_token' => $plainToken ? hash('sha256', $plainToken) : null,
             'recipient_name' => $request->recipient_name,
             'recipient_email' => $request->recipient_email,
             'message' => $request->message,
@@ -96,7 +102,7 @@ class ReverseSharesController extends Controller
         sendEmail::dispatch($request->recipient_email, reverseShareInviteMail::class, [
             'user' => $user,
             'invite' => $invite,
-            'token' => $encryptedToken, // Will be null for existing users
+            'token' => $plainToken, // null for existing users
             'isExistingUser' => $existingUser !== null
         ]);
 

--- a/app/Models/ReverseShareInvite.php
+++ b/app/Models/ReverseShareInvite.php
@@ -9,6 +9,7 @@ class ReverseShareInvite extends Model
   protected $fillable = [
     'user_id',
     'guest_user_id',
+    'guest_token',
     'recipient_name',
     'recipient_email',
     'message',

--- a/database/migrations/2026_04_29_000000_add_guest_token_to_reverse_share_invites.php
+++ b/database/migrations/2026_04_29_000000_add_guest_token_to_reverse_share_invites.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Replaces the JWT-based invite token approach with a secure random token
+     * stored directly in the database. The JWT approach was broken because the
+     * token TTL (default 60 min) was far shorter than the invite expiry (7 days),
+     * causing invite links to stop working after one hour.
+     */
+    public function up(): void
+    {
+        Schema::table('reverse_share_invites', function (Blueprint $table) {
+            $table->string('guest_token', 64)->nullable()->after('guest_user_id');
+            $table->index('guest_token');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reverse_share_invites', function (Blueprint $table) {
+            $table->dropIndex(['guest_token']);
+            $table->dropColumn('guest_token');
+        });
+    }
+};


### PR DESCRIPTION
## Problem

Guest invite links (sent to people without an Erugo account) stop working
after 60 minutes, even though the invite is valid for 7 days.

## Root cause

The code generated a JWT and embedded it in the invite link:

    $token = auth()->tokenById($guestUser->id);  // TTL: 60 min (JWT_TTL default)
    $encryptedToken = Crypt::encryptString($token);

The JWT expires after 60 minutes. The guest cannot log in any other way
since their password is randomly generated and unknown to anyone.

## Fix

Replace the JWT-in-URL with a secure random token stored in the database:
- `Str::random(64)` generates the token
- Only its SHA-256 hash is stored in a new `guest_token` column
- Validity is controlled by `invite.expires_at` (7 days), not JWT TTL
- No frontend changes needed