### PR TITLE
Low priority: Clean up share expiration message styling.

### DIFF
--- a/resources/js/components/downloader.vue
+++ b/resources/js/components/downloader.vue
@@ -224,7 +224,7 @@ const filesByDirectory = computed(() => {
           <TrendingDown />
           {{ $t('share.download_limit_reached') }}
         </h1>
-        <p>
+        <p class="mx-5 text-center">
           {{ $t('share.download_limit_reached.message') }}
         </p>
       </template>


### PR DESCRIPTION
Previous vs new

<img width="240" alt="image" src="https://github.com/user-attachments/assets/1c19c13e-03d7-4905-9f32-a99ecfbd3809" />
<img width="240" alt="image" src="https://github.com/user-attachments/assets/2fb5fced-0c41-4327-a2bb-38273b8054ab" />

Changed with the bootstrap `class="mx-5 text-center"` on the respective paragraph.

See #231 
