### PR TITLE
Add ERUGO_SHARES_PATH env var for separate uploads volume

### DIFF
--- a/docker/alpine/start-container
+++ b/docker/alpine/start-container
@@ -172,6 +172,29 @@ if [ -d /var/www/html/storage/app/public/backgrounds ] && [ "$(ls -A /var/www/ht
     echo "Backgrounds migration complete."
 fi
 
+# If ERUGO_SHARES_PATH is set, point storage/app/shares at it via a symlink
+if [ -n "$ERUGO_SHARES_PATH" ]; then
+    echo "Configuring shares path: $ERUGO_SHARES_PATH"
+    mkdir -p "$ERUGO_SHARES_PATH"
+    chown -R erugo:erugo "$ERUGO_SHARES_PATH"
+
+    # Move any existing files over the first time this is enabled
+    if [ -d /var/www/html/storage/app/shares ] && [ ! -L /var/www/html/storage/app/shares ]; then
+        if [ "$(ls -A /var/www/html/storage/app/shares 2>/dev/null)" ]; then
+            echo "Migrating existing shares to $ERUGO_SHARES_PATH..."
+            cp -rn /var/www/html/storage/app/shares/. "$ERUGO_SHARES_PATH/" 2>/dev/null || true
+        fi
+        rm -rf /var/www/html/storage/app/shares
+    fi
+
+    # Replace any old symlink that points somewhere else
+    if [ -L /var/www/html/storage/app/shares ]; then
+        rm /var/www/html/storage/app/shares
+    fi
+
+    ln -s "$ERUGO_SHARES_PATH" /var/www/html/storage/app/shares
+fi
+
 # Create symlinks for public assets (images, backgrounds) pointing to storage
 echo "Creating storage symlinks..."
 # Remove any existing symlinks or directories that conflict

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,22 @@ The above docker-compose.yml provides a basic configuration starting point that 
 docker compose up -d
 ``` 
 
+If you'd rather keep uploaded files on a separate volume from the database, set `ERUGO_SHARES_PATH` and mount that path in. The SQLite database can be moved the same way using `DB_DATABASE`.
+
+```yaml
+services:
+  app:
+    image: wardy784/erugo:latest
+    restart: unless-stopped
+    environment:
+      - ERUGO_SHARES_PATH=/data/shares
+    volumes:
+      - ./erugo-storage:/var/www/html/storage
+      - /mnt/bulk/shares:/data/shares
+    ports:
+      - "9998:80"
+```
+
 ## Screenshots
 
 ![Upload Interface](.github/images/screenshots/main-screen-with-files.png)


### PR DESCRIPTION
Adds an optional `ERUGO_SHARES_PATH` env var to the alpine entrypoint. When it's set, `storage/app/shares` becomes a symlink to whatever path you point it at, so uploads can live on a different volume than the SQLite database and the rest of the app storage.

Useful if you want the database on a fast disk and bulk uploads on a slower or larger one.

If you set the env var on an install that already has files in `app/shares`, those files are copied to the new location with `cp -n` (won't overwrite anything already there) and the original directory is replaced with the symlink. If the env var isn't set, the script behaves the same as before.

The SQLite database can already be moved with `DB_DATABASE`, so both knobs are available now. README has a second compose example showing the layout.

Tested:
- fresh install without the env var
- fresh install with the env var pointing at a mounted volume
- adding the env var to an existing install with files in `app/shares`
- restarting with the env var unchanged
- changing the env var to a different path between restarts
- removing the env var after it had been set