### PR TITLE
Enhance user management, recipient and invite forms to prevent browser autofill

### DIFF
--- a/resources/js/components/recipient.vue
+++ b/resources/js/components/recipient.vue
@@ -80,8 +80,11 @@ defineExpose({
     <div class="recipient-popover" :class="{ active: isPopoverOpen }" ref="recipientPopoverRef">
       <div class="recipient-popover-content">
         <div>
-          <input type="text" v-model="recipient.name" :placeholder="$t('full_name')" @keyup.enter="moveFocusToEmail" />
-          <input type="text" v-model="recipient.email" :placeholder="$t('email')" ref="emailInput" @keyup.enter="togglePopover" />
+          <!-- Hidden decoy fields to prevent browser password save prompts -->
+          <input type="text" name="prevent_autofill_1" style="display:none" tabindex="-1" autocomplete="off" />
+          <input type="password" name="prevent_autofill_2" style="display:none" tabindex="-1" autocomplete="off" />
+          <input type="text" v-model="recipient.name" :placeholder="$t('full_name')" @keyup.enter="moveFocusToEmail" autocomplete="off" />
+          <input type="text" v-model="recipient.email" :placeholder="$t('email')" ref="emailInput" @keyup.enter="togglePopover" autocomplete="off" />
         </div>
         <div class="button-container">
           <div class="button-outside-label">

--- a/resources/js/components/reverseInvite.vue
+++ b/resources/js/components/reverseInvite.vue
@@ -48,6 +48,9 @@ defineExpose({
         {{ $t('settings.title.reverse_invite') }}
       </h2>
       <p>{{ $t('settings.reverse_invite.description') }}</p>
+      <!-- Hidden decoy fields to prevent browser password save prompts -->
+      <input type="text" name="prevent_autofill_1" style="display:none" tabindex="-1" autocomplete="off" />
+      <input type="password" name="prevent_autofill_2" style="display:none" tabindex="-1" autocomplete="off" />
       <div class="input-container">
         <label for="edit_user_email">{{ $t('settings.users.email') }}</label>
         <input
@@ -56,6 +59,7 @@ defineExpose({
           id="edit_user_email"
           :placeholder="$t('settings.users.email')"
           required
+          autocomplete="off"
           :class="{ error: errors.email }"
         />
         <div class="error-message" v-if="errors.email">
@@ -70,6 +74,7 @@ defineExpose({
           id="edit_user_name"
           :placeholder="$t('settings.users.name')"
           required
+          autocomplete="off"
           :class="{ error: errors.name }"
         />
         <div class="error-message" v-if="errors.name">

--- a/resources/js/components/settings/myProfile.vue
+++ b/resources/js/components/settings/myProfile.vue
@@ -191,14 +191,17 @@ const handleUnlinkProvider = async (provider) => {
               </div>
 
               <div class="setting-group-body">
+                <!-- Hidden decoy fields to prevent browser password save prompts -->
+                <input type="text" name="prevent_autofill_1" style="display:none" tabindex="-1" autocomplete="off" />
+                <input type="password" name="prevent_autofill_2" style="display:none" tabindex="-1" autocomplete="off" />
                 <div class="setting-group-body-item">
                   <label for="email">{{ $t('settings.account.email') }}</label>
-                  <input type="text" id="email" v-model="profile.email" />
+                  <input type="text" id="email" v-model="profile.email" autocomplete="off" />
                 </div>
 
                 <div class="setting-group-body-item">
                   <label for="name">{{ $t('settings.account.name') }}</label>
-                  <input type="text" id="name" v-model="profile.name" />
+                  <input type="text" id="name" v-model="profile.name" autocomplete="off" />
                 </div>
 
                 <div class="setting-group-body-item mt-3">

--- a/resources/js/components/settings/users.vue
+++ b/resources/js/components/settings/users.vue
@@ -246,6 +246,9 @@ const confirmForceResetPassword = () => {
       <p v-html="$t('settings.users.add_user_description')"></p>
       <p v-if="selfRegistrationEnabled">{{ $t('settings.users.add_user_self_registration_tip_on') }}</p>
       <p v-else>{{ $t('settings.users.add_user_self_registration_tip_off') }}</p>
+      <!-- Hidden decoy fields to prevent browser password save prompts -->
+      <input type="text" name="prevent_autofill_1" style="display:none" tabindex="-1" autocomplete="off" />
+      <input type="password" name="prevent_autofill_2" style="display:none" tabindex="-1" autocomplete="off" />
       <div class="input-container">
         <label for="new_user_email">{{ $t('settings.users.email') }}</label>
         <input
@@ -254,6 +257,7 @@ const confirmForceResetPassword = () => {
           id="new_user_email"
           :placeholder="$t('settings.users.email')"
           required
+          autocomplete="off"
           :class="{ error: errors.email }"
         />
         <div class="error-message" v-if="errors.email">
@@ -268,6 +272,7 @@ const confirmForceResetPassword = () => {
           id="new_user_name"
           :placeholder="$t('settings.users.name')"
           required
+          autocomplete="off"
           :class="{ error: errors.name }"
         />
         <div class="error-message" v-if="errors.name">
@@ -304,6 +309,9 @@ const confirmForceResetPassword = () => {
         <UserPlus />
         {{ $t('settings.title.users.edit', { name: editUser.name }) }}
       </h2>
+      <!-- Hidden decoy fields to prevent browser password save prompts -->
+      <input type="text" name="prevent_autofill_1" style="display:none" tabindex="-1" autocomplete="off" />
+      <input type="password" name="prevent_autofill_2" style="display:none" tabindex="-1" autocomplete="off" />
       <div class="input-container">
         <label for="edit_user_email">{{ $t('settings.users.email') }}</label>
         <input
@@ -312,6 +320,7 @@ const confirmForceResetPassword = () => {
           id="edit_user_email"
           :placeholder="$t('settings.users.email')"
           required
+          autocomplete="off"
           :class="{ error: errors.email }"
         />
         <div class="error-message" v-if="errors.email">
@@ -326,6 +335,7 @@ const confirmForceResetPassword = () => {
           id="edit_user_name"
           :placeholder="$t('settings.users.name')"
           required
+          autocomplete="off"
           :class="{ error: errors.name }"
         />
         <div class="error-message" v-if="errors.name">


### PR DESCRIPTION
Same fix as e7bdddf but for the user management, recipient and reverse invite forms. Password managers were popping their fill overlay on every focus.

- Added hidden input fields to deter browser password save prompts.
- Updated email and name fields on the add-user, edit-user, profile, recipient and reverse invite forms to disable autofill.