### PR TITLE
Add option to auto-redirect login to a single SSO provider

### DIFF
--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -438,6 +438,14 @@ class SettingsSeeder extends Seeder
                 'updated_at' => now()
             ],
             [
+                'key' => 'sso_auto_launch',
+                'value' => 'false',
+                'previous_value' => null,
+                'group' => 'system.auth',
+                'created_at' => now(),
+                'updated_at' => now()
+            ],
+            [
                 'key' => 'email_subject_emailVerificationMail.twig',
                 'value' => 'Verify your email address',
                 'previous_value' => null,

--- a/resources/js/components/auth.vue
+++ b/resources/js/components/auth.vue
@@ -53,6 +53,19 @@ const isRegistering = ref(false)
 const isVerifying = ref(false)
 const isResending = ref(false)
 
+// Hide the login UI until we know whether we are about to redirect to an SSO
+// provider, otherwise the form briefly flashes before the navigation fires
+const ssoAutoLaunchEnabled = domData().sso_auto_launch === true
+const initialUrlParams = new URLSearchParams(window.location.search)
+const initialAutoLaunchParam = initialUrlParams.get('autoLaunch')
+const mightAutoLaunch =
+  (ssoAutoLaunchEnabled || initialAutoLaunchParam === '1') &&
+  initialAutoLaunchParam !== '0' &&
+  !domData().token &&
+  !initialUrlParams.get('invite_id') &&
+  !initialUrlParams.get('invite_token')
+const pendingAutoLaunchDecision = ref(mightAutoLaunch)
+
 onMounted(async () => {
   const token = domData().token
   if (token) {
@@ -63,7 +76,9 @@ onMounted(async () => {
   // Parse URL parameters FIRST (before any async operations)
   // This ensures invite_id is set before attemptRefresh() completes
   const urlParams = new URLSearchParams(window.location.search)
-  
+  const inviteToken = urlParams.get('invite_token')
+  const autoLaunchParam = urlParams.get('autoLaunch')
+
   // Check for invite_id (for existing users who need to log in)
   const inviteId = urlParams.get('invite_id')
   if (inviteId) {
@@ -73,12 +88,29 @@ onMounted(async () => {
     window.history.replaceState({}, document.title, window.location.pathname)
   }
 
-  // Now try to refresh (if user is already logged in, this will accept the pending invite)
-  attemptRefresh()
+  // Refresh and providers run in parallel because the auto-launch decision below
+  // needs both store.isLoggedIn() and authProviders.value.length to be settled
+  const [, providers] = await Promise.all([
+    attemptRefresh(),
+    getAvailableAuthProviders().catch(() => [])
+  ])
+  authProviders.value = providers
 
-  getAvailableAuthProviders().then((data) => {
-    authProviders.value = data
-  })
+  const escapeConditions =
+    haveResetToken.value ||
+    pendingInviteId.value ||
+    inviteToken ||
+    autoLaunchParam === '0' ||
+    store.isLoggedIn()
+  const forceLaunch =
+    autoLaunchParam === '1' && authProviders.value.length >= 1 && !escapeConditions
+  const naturalLaunch =
+    ssoAutoLaunchEnabled && authProviders.value.length === 1 && !escapeConditions
+  if (forceLaunch || naturalLaunch) {
+    attemptAuthProviderLogin(authProviders.value[0].id)
+    return
+  }
+  pendingAutoLaunchDecision.value = false
 
   // Check if self-registration is enabled
   try {
@@ -90,7 +122,7 @@ onMounted(async () => {
   }
 
   // Grab reverse share token from url (for guest users)
-  reverseShareToken.value = urlParams.get('invite_token')
+  reverseShareToken.value = inviteToken
   if (reverseShareToken.value) {
     try {
       await acceptReverseShareInvite(reverseShareToken.value)
@@ -280,8 +312,11 @@ const switchToLogin = () => {
 </script>
 
 <template>
+  <!-- Empty placeholder while we decide whether to auto-launch to an SSO provider -->
+  <div class="auth-container auth-pending" v-if="pendingAutoLaunchDecision"></div>
+
   <!-- Verification Code Screen -->
-  <div class="auth-container" v-if="verificationMode">
+  <div class="auth-container" v-else-if="verificationMode">
     <div class="auth-container-inner">
       <h1>{{ $t('auth.verify_email') }}</h1>
       <p>{{ $t('auth.verification_code_sent', { email: registrationEmail }) }}</p>

--- a/resources/js/components/settings/system.vue
+++ b/resources/js/components/settings/system.vue
@@ -72,7 +72,8 @@ const settings = ref({
   smtp_sender_address: '',
   self_registration_enabled: false,
   self_registration_allow_any_domain: true,
-  self_registration_allowed_domains: ''
+  self_registration_allowed_domains: '',
+  sso_auto_launch: false
 })
 
 // Pattern presets for share URL generation
@@ -985,6 +986,23 @@ const handleDeleteAuthProvider = async (id) => {
                     />
                     <p class="help-text">{{ $t('settings.system.self_registration_allowed_domains_help') }}</p>
                   </div>
+                </div>
+
+                <hr class="my-4" />
+
+                <h5 id="sso_auto_launch_heading" class="mb-3">{{ $t('settings.system.sso_auto_launch_heading') }}</h5>
+                <div class="setting-group-body-item">
+                  <div class="checkbox-container">
+                    <input
+                      type="checkbox"
+                      id="sso_auto_launch"
+                      v-model="settings.sso_auto_launch"
+                    />
+                    <label for="sso_auto_launch">
+                      {{ $t('settings.system.sso_auto_launch') }}
+                    </label>
+                  </div>
+                  <p class="help-text">{{ $t('settings.system.sso_auto_launch_description') }}</p>
                 </div>
 
                 <hr class="my-4" />

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -872,6 +872,9 @@
       "smtp_sender_name_description": "The display name that will appear as the sender of system emails. Users will see this name in their email client (e.g. \"Your App Name\" or \"Your App Support\").",
       "smtp_username": "SMTP Username",
       "smtp_username_description": "The username required to authenticate with your SMTP server. This is typically the email address or account name associated with your email service.",
+      "sso_auto_launch": "Auto-redirect to SSO provider on login",
+      "sso_auto_launch_description": "When enabled and exactly one auth provider is configured, the login page redirects to that provider automatically. To reach the local login form, add ?autoLaunch=0 to the URL or use the browser back button.",
+      "sso_auto_launch_heading": "Auto-redirect on login",
       "upload_modes": "Upload modes",
       "your_auth_providers": "Your Auth Providers"
     },

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ function getSettings()
         ->orWhere('key', 'allow_reverse_shares')
         ->orWhere('key', 'max_expiry_time')
         ->orWhere('key', 'default_expiry_time')
+        ->orWhere('key', 'sso_auto_launch')
         ->get();
 
     $settings = $settings->map(function ($setting) use ($settingsService) {


### PR DESCRIPTION
Adds an `sso_auto_launch` setting. When enabled and exactly one auth provider is configured, the login page sends users straight to that provider instead of showing the local email/password form first.

This mirrors Immich's `autoLaunch` pattern (https://immich.app/docs/administration/oauth/) so admins who have used it there should recognise the behaviour.

Default is off so existing installs behave exactly as before.

## Behaviour

- Toggle lives in System Settings > Auth, between Self Registration and Your Auth Providers.
- When on and exactly one provider is enabled, visiting `/login` redirects to that provider.
- When on and zero or multiple providers are enabled, the local form renders as usual (no arbitrary "pick the first one" guess).
- `/login?autoLaunch=0` always shows the local form. Useful when SSO is broken and an admin needs to log in locally.
- `/login?autoLaunch=1` forces the redirect even when the toggle is off. Useful when launching Erugo from an SSO portal entry point.
- Redirect is skipped automatically when a password reset token, `invite_id`, or `invite_token` is in the URL, or when the user already has a valid session.
- Redirect uses normal `window.location` navigation so the browser back button works.

## Files changed

- `database/seeders/SettingsSeeder.php`: new `sso_auto_launch` row, default `false`.
- `routes/web.php`: include the new key in the boot payload so the redirect can fire on first paint.
- `resources/js/components/settings/system.vue`: admin toggle in the Auth section.
- `resources/js/components/auth.vue`: redirect logic in `onMounted`, plus the providers fetch is now awaited together with the session refresh so the decision sees both pieces of state.
- `resources/js/i18n/en.json`: three new keys for the admin UI.

## Notes

Happy to rework if you'd prefer a different setting name, a different URL parameter, the empty-placeholder flash-prevention removed, or no per-request override at all.