### PR TITLE
Enable templating in Email subjects

### DIFF
--- a/app/Mail/Concerns/RendersSubject.php
+++ b/app/Mail/Concerns/RendersSubject.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Mail\Concerns;
+
+use App\Models\Setting;
+use App\Services\SettingsService;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+trait RendersSubject
+{
+    /**
+     * Render an email subject stored in settings through Twig, giving it the same
+     * variables the email body receives (the Mailable's public properties plus the
+     * global `settings` view data). This lets subjects use the same {{ }} placeholders
+     * as the body, e.g. {{ share.name }} or {{ sender_name }}.
+     */
+    protected function renderSubject(string $settingKey): string
+    {
+        $raw = optional(Setting::where('key', $settingKey)->first())->value ?? '';
+
+        // Public properties of the Mailable, identical to what the body view sees.
+        $context = $this->buildViewData();
+
+        try {
+            $context['settings'] = app(SettingsService::class)->getGlobalViewData();
+        } catch (\Throwable $e) {
+            $context['settings'] = [];
+        }
+
+        try {
+            // autoescape OFF: subjects are plain text, so '&'/'<' must not become entities.
+            $twig = new Environment(new ArrayLoader(), ['autoescape' => false]);
+            return $twig->createTemplate($raw)->render($context);
+        } catch (\Throwable $e) {
+            // A malformed template must never break email sending.
+            return $raw;
+        }
+    }
+}

--- a/app/Mail/accountCreatedMail.php
+++ b/app/Mail/accountCreatedMail.php
@@ -10,9 +10,10 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\User;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 class accountCreatedMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     public $token;
     public $user;
@@ -32,7 +33,7 @@ class accountCreatedMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_accountCreatedMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_accountCreatedMail.twig'),
         );
     }
 

--- a/app/Mail/emailVerificationMail.php
+++ b/app/Mail/emailVerificationMail.php
@@ -10,10 +10,11 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\User;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 
 class emailVerificationMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     public $code;
     public $user;
@@ -33,7 +34,7 @@ class emailVerificationMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_emailVerificationMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_emailVerificationMail.twig'),
         );
     }
 

--- a/app/Mail/passwordResetMail.php
+++ b/app/Mail/passwordResetMail.php
@@ -10,9 +10,10 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\User;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 class passwordResetMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     public $token;
     public $user;
@@ -32,7 +33,7 @@ class passwordResetMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_passwordResetMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_passwordResetMail.twig'),
         );
     }
 

--- a/app/Mail/reverseShareInviteMail.php
+++ b/app/Mail/reverseShareInviteMail.php
@@ -11,10 +11,11 @@ use Illuminate\Queue\SerializesModels;
 use App\Models\User;
 use App\Models\ReverseShareInvite;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 
 class reverseShareInviteMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     /**
      * Create a new message instance.
@@ -44,7 +45,7 @@ class reverseShareInviteMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_reverseShareInviteMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_reverseShareInviteMail.twig'),
         );
     }
 

--- a/app/Mail/shareCreatedMail.php
+++ b/app/Mail/shareCreatedMail.php
@@ -11,9 +11,10 @@ use Illuminate\Queue\SerializesModels;
 use App\Models\User;
 use App\Models\Share;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 class shareCreatedMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     /**
      * Create a new message instance.
@@ -39,7 +40,7 @@ class shareCreatedMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_shareCreatedMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_shareCreatedMail.twig'),
         );
     }
 

--- a/app/Mail/shareDeletedWarningMail.php
+++ b/app/Mail/shareDeletedWarningMail.php
@@ -10,9 +10,10 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\Share;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 class shareDeletedWarningMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     /**
      * Create a new message instance.
@@ -30,7 +31,7 @@ class shareDeletedWarningMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_shareDeletedWarningMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_shareDeletedWarningMail.twig'),
         );
     }
 

--- a/app/Mail/shareDeletionWarningMail.php
+++ b/app/Mail/shareDeletionWarningMail.php
@@ -10,9 +10,10 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\Share;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 class shareDeletionWarningMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     /**
      * Create a new message instance.
@@ -34,7 +35,7 @@ class shareDeletionWarningMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_shareDeletionWarningMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_shareDeletionWarningMail.twig'),
         );
     }
 

--- a/app/Mail/shareDownloadedMail.php
+++ b/app/Mail/shareDownloadedMail.php
@@ -10,9 +10,10 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\Share;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 class shareDownloadedMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
     public $share;
     /**
      * Create a new message instance.
@@ -28,7 +29,7 @@ class shareDownloadedMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_shareDownloadedMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_shareDownloadedMail.twig'),
         );
     }
 

--- a/app/Mail/shareExpiredWarningMail.php
+++ b/app/Mail/shareExpiredWarningMail.php
@@ -10,9 +10,10 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\Share;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 class shareExpiredWarningMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     /**
      * Create a new message instance.
@@ -30,7 +31,7 @@ class shareExpiredWarningMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_shareExpiredWarningMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_shareExpiredWarningMail.twig'),
         );
     }
 

--- a/app/Mail/shareExpiryWarningMail.php
+++ b/app/Mail/shareExpiryWarningMail.php
@@ -10,9 +10,10 @@ use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
 use App\Models\Share;
 use App\Models\Setting;
+use App\Mail\Concerns\RendersSubject;
 class shareExpiryWarningMail extends Mailable
 {
-    use Queueable, SerializesModels;
+    use Queueable, SerializesModels, RendersSubject;
 
     /**
      * Create a new message instance.
@@ -32,7 +33,7 @@ class shareExpiryWarningMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: Setting::where('key', 'email_subject_shareExpiryWarningMail.twig')->first()->value,
+            subject: $this->renderSubject('email_subject_shareExpiryWarningMail.twig'),
         );
     }
 


### PR DESCRIPTION
I was missing this feature to be able to use {{share.name}} in email titles.

Issue #213 mentioned the same.

This PR is NOT Tested yet, will do soon, if there are any concerns or potential review comments please bring them up so I can take a look

