### PR TITLE
fix: format time remaining as h/m/s instead of raw seconds

### DIFF
--- a/resources/js/components/uploader.vue
+++ b/resources/js/components/uploader.vue
@@ -18,7 +18,7 @@ import {
   LockOpen,
   RotateCcw
 } from 'lucide-vue-next'
-import { niceFileSize, niceFileType, simpleUUID } from '../utils'
+import { niceFileSize, niceFileType, niceTime, simpleUUID } from '../utils'
 import { getHealth, getMyProfile, uploadFilesInChunks, logout } from '../api'
 import Recipient from './recipient.vue'
 import { uploadController } from '../store'
@@ -834,7 +834,7 @@ const filesByDirectory = computed(() => {
               {{ niceFileSize(uploadSpeed) }}/s
             </div>
             <div class="progress-item time-remaining-text">
-              {{ Math.round(timeRemaining) }}{{ $t('uploader.time_remaining_suffix', 's') }} {{ t('uploader.time_remaining_text', 'remaining') }}
+              {{ niceTime(timeRemaining) }} {{ t('uploader.time_remaining_text', 'remaining') }}
             </div>
             
             <div v-if="currentFileName" class="progress-item file-name-text">

--- a/resources/js/utils.js
+++ b/resources/js/utils.js
@@ -12,6 +12,15 @@ const simpleUUID = () => {
   });
 }
 
+const niceTime = seconds => {
+  if (seconds < 0) return '0s'
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${Math.round(seconds % 60)}s`
+  const h = Math.floor(seconds / 3600)
+  const m = Math.round((seconds % 3600) / 60)
+  return `${h}h ${m}m`
+}
+
 const niceFileSize = size => {
   //return in most readable format
   if (size < 1024) return `${size} bytes`
@@ -115,4 +124,4 @@ const convertToRealType = value => {
   return value
 }
 
-export { niceFileSize, niceFileType, niceExpirationDate, timeUntilExpiration, getApiUrl, getTusdUrl, simpleUUID, niceFileName, niceDate, niceString, niceNumber, mapSettings }
+export { niceTime, niceFileSize, niceFileType, niceExpirationDate, timeUntilExpiration, getApiUrl, getTusdUrl, simpleUUID, niceFileName, niceDate, niceString, niceNumber, mapSettings }


### PR DESCRIPTION
Currently the upload progress timer displays raw seconds regardless of duration, e.g. 3600s remaining for a 1 hour upload. This is hard to read for anything over a minute.
This PR adds a niceTime() utility function that formats seconds into a human-readable string:

< 60s → 45s
< 3600s → 2m 19s
>= 3600s → 1h 30m

Changes:

resources/js/utils.js — Added niceTime(seconds) function and exported it
resources/js/components/uploader.vue — Imported niceTime and replaced Math.round(timeRemaining) + suffix with niceTime(timeRemaining) in the progress display

Before: 139s remaining

After: 2m 19s remaining

example image:
<img width="523" height="174" alt="Screenshot 2026-06-16 at 11 28 23" src="https://github.com/user-attachments/assets/cd4b4e0d-5592-4d9d-bfae-3dc6e3b79937" />
