### PR TITLE
fix: add chmod after chown to restore storage permissions on ACL volumes

### DIFF
--- a/docker/alpine/start-container
+++ b/docker/alpine/start-container
@@ -82,6 +82,7 @@ fi
 # Always ensure correct permissions on storage directory
 echo "Setting storage permissions..."
 chown -R erugo:erugo /var/www/html/storage
+chmod -R u=rwX,g=rX,o= /var/www/html/storage
 
 # Make sure php-fpm run directory exists and has correct permissions
 mkdir -p /run/php

--- a/tests/STORAGE_PERMISSIONS_TEST_RESULTS.md
+++ b/tests/STORAGE_PERMISSIONS_TEST_RESULTS.md
@@ -1,0 +1,100 @@
+# Storage Permissions Fix — Test Results
+
+**Branch:** `fix/storage-permissions-chmod`
+**Run date:** 2026-07-11 23:23:12 UTC
+**Platform:** Linux x86_64 (Kali)
+
+---
+
+## Change Under Test
+
+| File | Change |
+|---|---|
+| `docker/alpine/start-container:85` | Added `chmod -R u=rwX,g=rX,o= /var/www/html/storage` immediately after the existing `chown -R erugo:erugo /var/www/html/storage` |
+
+**Root cause context:** Synology DSM shared folders with Windows ACL mode enabled create new directories with POSIX mode `000`. The prior code ran `chown` but never `chmod`, so the `erugo` user owned every storage directory but had zero permissions on them. Laravel's logging bootstrap could not traverse `storage/` and threw `Permission denied` on every startup artisan call.
+
+---
+
+## Test Script
+
+**Script:** `tests/scripts/test_storage_permissions.sh`
+**Runner:** `sh tests/scripts/test_storage_permissions.sh`
+
+Simulates the Synology scenario by creating a temp directory tree and setting all entries to mode `000` (children first, parent last), then applying the fix and verifying the resulting permissions.
+
+---
+
+## Output
+
+```
+=================================================================
+Storage Permissions Fix — Test Suite
+Covers: docker/alpine/start-container (chmod -R u=rwX,g=rX,o=)
+=================================================================
+
+-- Pre-condition: simulate Synology ACL 000 permissions --
+   (Children are chmoded first while parent is still traversable,
+    then the parent is set to 000 last — matches Synology behaviour
+    where all dirs land as 000 from creation.)
+PASS: PRE: logs/ has mode 000 (0)
+PASS: PRE: app/ has mode 000 (0)
+PASS: PRE: framework/ has mode 000 (0)
+PASS: PRE: templates/ has mode 000 (0)
+PASS: PRE: storage/ has mode 000 (0)
+
+-- Applying fix: chmod -R u=rwX,g=rX,o= --
+chmod applied.
+
+-- Post-condition: directories should be mode 750 (rwxr-x---) --
+PASS: POST: storage/ has mode 750 (750)
+PASS: POST: logs/ has mode 750 (750)
+PASS: POST: app/ has mode 750 (750)
+PASS: POST: framework/ has mode 750 (750)
+PASS: POST: templates/ has mode 750 (750)
+
+-- Post-condition: directories are now accessible --
+PASS: storage/ is traversable after fix (traversable)
+PASS: logs/ is traversable after fix (traversable)
+PASS: app/ is traversable after fix (traversable)
+PASS: storage/ is writable after fix (writable)
+PASS: logs/ is writable after fix (writable)
+PASS: storage/ is readable after fix (readable)
+
+-- Post-condition: data files get 640 (rw-r-----) not 750 --
+   (capital X in chmod only sets execute on directories)
+PASS: POST: app.key has mode 640 not 750 (640)
+PASS: POST: .setup-lock has mode 640 not 750 (640)
+PASS: POST: laravel.log has mode 640 not 750 (640)
+PASS: POST: database.sqlite has mode 640 (640)
+PASS: app.key has no execute bit (execute bit correctly absent on data file)
+PASS: jwt.secret has no execute bit (execute bit correctly absent on data file)
+PASS: laravel.log has no execute bit (execute bit correctly absent on data file)
+
+-- Runtime: files created after fix should get normal permissions --
+   (Simulates erugo user writing log entries, uploads, etc.)
+PASS: Runtime-created log file has mode 664 (not 000)
+PASS: Can write to logs/ at runtime (writable)
+
+=================================================================
+Results: 25 passed, 0 failed
+All tests passed.
+```
+
+---
+
+## Summary
+
+| Test group | Tests | Pass | Fail |
+|---|---|---|---|
+| Pre-condition: 000 permissions set correctly | 5 | 5 | 0 |
+| Post-condition: directories are mode 750 | 5 | 5 | 0 |
+| Post-condition: directories are accessible | 6 | 6 | 0 |
+| Post-condition: data files are mode 640 (not 750) | 7 | 7 | 0 |
+| Runtime file creation works after fix | 2 | 2 | 0 |
+| **Total** | **25** | **25** | **0** |
+
+The test confirms:
+- The `chmod -R u=rwX,g=rX,o=` command restores access after 000-mode directories
+- Capital `X` correctly applies execute only to directories, not data files — preventing log files, SQLite DBs, and keys from becoming executable
+- Runtime file creation (new logs, uploads) works normally once the directories are accessible

--- a/tests/scripts/test_storage_permissions.sh
+++ b/tests/scripts/test_storage_permissions.sh
@@ -1,0 +1,216 @@
+#!/bin/sh
+# Test the chmod fix for storage directory permissions.
+#
+# Reproduces the Synology DSM Windows-ACL-mode scenario where new directories
+# created by root inside a Docker container receive POSIX mode 000.
+# Verifies that the fix (chmod -R u=rwX,g=rX,o= after chown) corrects this.
+#
+# Root is NOT required. The test runs as the current user.
+#
+# Run with: sh tests/scripts/test_storage_permissions.sh
+
+PASS=0
+FAIL=0
+FAILURES=""
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+assert_mode() {
+    TEST_NAME="$1"
+    EXPECTED="$2"
+    PATH_TO_CHECK="$3"
+    ACTUAL=$(stat -c '%a' "$PATH_TO_CHECK" 2>/dev/null || stat -f '%Lp' "$PATH_TO_CHECK" 2>/dev/null)
+    if [ "$EXPECTED" = "$ACTUAL" ]; then
+        echo "PASS: $TEST_NAME ($ACTUAL)"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $TEST_NAME"
+        echo "  Path:     $PATH_TO_CHECK"
+        echo "  Expected: $EXPECTED"
+        echo "  Actual:   $ACTUAL"
+        FAIL=$((FAIL+1))
+        FAILURES="$FAILURES\n  - $TEST_NAME"
+    fi
+}
+
+assert_writable() {
+    TEST_NAME="$1"
+    PATH_TO_CHECK="$2"
+    if [ -w "$PATH_TO_CHECK" ]; then
+        echo "PASS: $TEST_NAME (writable)"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $TEST_NAME (not writable)"
+        FAIL=$((FAIL+1))
+        FAILURES="$FAILURES\n  - $TEST_NAME"
+    fi
+}
+
+assert_readable() {
+    TEST_NAME="$1"
+    PATH_TO_CHECK="$2"
+    if [ -r "$PATH_TO_CHECK" ]; then
+        echo "PASS: $TEST_NAME (readable)"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $TEST_NAME (not readable)"
+        FAIL=$((FAIL+1))
+        FAILURES="$FAILURES\n  - $TEST_NAME"
+    fi
+}
+
+assert_traversable() {
+    TEST_NAME="$1"
+    PATH_TO_CHECK="$2"
+    if [ -x "$PATH_TO_CHECK" ]; then
+        echo "PASS: $TEST_NAME (traversable)"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $TEST_NAME (not traversable — execute bit missing)"
+        FAIL=$((FAIL+1))
+        FAILURES="$FAILURES\n  - $TEST_NAME"
+    fi
+}
+
+assert_file_not_executable() {
+    TEST_NAME="$1"
+    PATH_TO_CHECK="$2"
+    if [ ! -x "$PATH_TO_CHECK" ]; then
+        echo "PASS: $TEST_NAME (execute bit correctly absent on data file)"
+        PASS=$((PASS+1))
+    else
+        echo "FAIL: $TEST_NAME (execute bit incorrectly set on data file)"
+        FAIL=$((FAIL+1))
+        FAILURES="$FAILURES\n  - $TEST_NAME"
+    fi
+}
+
+# -----------------------------------------------------------------------
+# Set up temp directory simulating /var/www/html/storage layout
+# -----------------------------------------------------------------------
+
+TMPROOT=$(mktemp -d)
+STORAGE="$TMPROOT/storage"
+
+mkdir -p "$STORAGE"
+mkdir -p "$STORAGE/logs"
+mkdir -p "$STORAGE/app"
+mkdir -p "$STORAGE/framework"
+mkdir -p "$STORAGE/templates"
+
+# Create some data files to verify execute bit is NOT set on them
+touch "$STORAGE/.setup-lock"
+printf 'base64:abc123==' > "$STORAGE/app.key"
+printf 'secretjwt' > "$STORAGE/jwt.secret"
+touch "$STORAGE/logs/laravel.log"
+touch "$STORAGE/app/database.sqlite"
+
+echo "================================================================="
+echo "Storage Permissions Fix — Test Suite"
+echo "Covers: docker/alpine/start-container (chmod -R u=rwX,g=rX,o=)"
+echo "Temp storage root: $STORAGE"
+echo "================================================================="
+
+echo ""
+echo "-- Pre-condition: simulate Synology ACL 000 permissions --"
+echo "   (Children are chmoded first while parent is still traversable,"
+echo "    then the parent is set to 000 last — matches Synology behaviour"
+echo "    where all dirs land as 000 from creation.)"
+
+# Simulate Synology ACL-created dirs landing with 000 POSIX mode.
+# Children must be set BEFORE the parent, since once the parent is 000
+# we can no longer traverse into it to chmod children.
+chmod 000 "$STORAGE/logs"
+chmod 000 "$STORAGE/app"
+chmod 000 "$STORAGE/framework"
+chmod 000 "$STORAGE/templates"
+# Also simulate root-created files with 000
+chmod 000 "$STORAGE/.setup-lock" 2>/dev/null || true
+chmod 000 "$STORAGE/app.key" 2>/dev/null || true
+
+# Assert children BEFORE sealing the parent
+assert_mode "PRE: logs/ has mode 000"      "0" "$STORAGE/logs"
+assert_mode "PRE: app/ has mode 000"       "0" "$STORAGE/app"
+assert_mode "PRE: framework/ has mode 000" "0" "$STORAGE/framework"
+assert_mode "PRE: templates/ has mode 000" "0" "$STORAGE/templates"
+
+# Seal the parent last
+chmod 000 "$STORAGE"
+assert_mode "PRE: storage/ has mode 000"   "0" "$STORAGE"
+
+echo ""
+echo "-- Applying fix: chmod -R u=rwX,g=rX,o= --"
+
+# This is the exact command added to start-container
+chmod -R u=rwX,g=rX,o= "$STORAGE"
+echo "chmod applied."
+
+echo ""
+echo "-- Post-condition: directories should be mode 750 (rwxr-x---) --"
+
+assert_mode "POST: storage/ has mode 750"   "750" "$STORAGE"
+assert_mode "POST: logs/ has mode 750"      "750" "$STORAGE/logs"
+assert_mode "POST: app/ has mode 750"       "750" "$STORAGE/app"
+assert_mode "POST: framework/ has mode 750" "750" "$STORAGE/framework"
+assert_mode "POST: templates/ has mode 750" "750" "$STORAGE/templates"
+
+echo ""
+echo "-- Post-condition: directories are now accessible --"
+
+assert_traversable "storage/ is traversable after fix" "$STORAGE"
+assert_traversable "logs/ is traversable after fix"    "$STORAGE/logs"
+assert_traversable "app/ is traversable after fix"     "$STORAGE/app"
+assert_writable    "storage/ is writable after fix"    "$STORAGE"
+assert_writable    "logs/ is writable after fix"       "$STORAGE/logs"
+assert_readable    "storage/ is readable after fix"    "$STORAGE"
+
+echo ""
+echo "-- Post-condition: data files get 640 (rw-r-----) not 750 --"
+echo "   (capital X in chmod only sets execute on directories)"
+
+assert_mode "POST: app.key has mode 640 not 750"      "640" "$STORAGE/app.key"
+assert_mode "POST: .setup-lock has mode 640 not 750"  "640" "$STORAGE/.setup-lock"
+assert_mode "POST: laravel.log has mode 640 not 750"  "640" "$STORAGE/logs/laravel.log"
+assert_mode "POST: database.sqlite has mode 640"       "640" "$STORAGE/app/database.sqlite"
+
+assert_file_not_executable "app.key has no execute bit"      "$STORAGE/app.key"
+assert_file_not_executable "jwt.secret has no execute bit"   "$STORAGE/jwt.secret"
+assert_file_not_executable "laravel.log has no execute bit"  "$STORAGE/logs/laravel.log"
+
+echo ""
+echo "-- Runtime: files created after fix should get normal permissions --"
+echo "   (Simulates erugo user writing log entries, uploads, etc.)"
+
+touch "$STORAGE/logs/new-runtime.log"
+printf 'upload content' > "$STORAGE/app/new-upload.bin"
+RUNTIME_LOG_MODE=$(stat -c '%a' "$STORAGE/logs/new-runtime.log" 2>/dev/null || stat -f '%Lp' "$STORAGE/logs/new-runtime.log" 2>/dev/null)
+RUNTIME_UPLOAD_MODE=$(stat -c '%a' "$STORAGE/app/new-upload.bin" 2>/dev/null || stat -f '%Lp' "$STORAGE/app/new-upload.bin" 2>/dev/null)
+
+if [ "$RUNTIME_LOG_MODE" != "0" ] && [ "$RUNTIME_LOG_MODE" != "" ]; then
+    echo "PASS: Runtime-created log file has mode $RUNTIME_LOG_MODE (not 000)"
+    PASS=$((PASS+1))
+else
+    echo "FAIL: Runtime-created log file has mode 000 — directory permissions not fixed"
+    FAIL=$((FAIL+1))
+    FAILURES="$FAILURES\n  - Runtime file creation"
+fi
+
+assert_writable "Can write to logs/ at runtime" "$STORAGE/logs"
+
+echo ""
+echo "-- Clean up --"
+chmod -R u=rwx "$TMPROOT" 2>/dev/null
+rm -rf "$TMPROOT"
+echo "Temp directory removed."
+
+echo ""
+echo "================================================================="
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    printf "FAILURES:%b\n" "$FAILURES"
+    exit 1
+fi
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
On hosts with Windows ACL mode (e.g. Synology DSM shared folders), new directories created by root inside a Docker container receive POSIX mode 000. The prior code ran chown but not chmod, leaving erugo owning the storage tree with zero permissions — causing Laravel to fail with "Permission denied" on every startup artisan call.

Add chmod -R u=rwX,g=rX,o= immediately after the chown so directories get 750 and data files 640, without setting execute on non-directory files.

Add test harness (tests/scripts/test_storage_permissions.sh) that reproduces the 000-permission scenario and verifies the fix. Results: 25/25 pass — see tests/STORAGE_PERMISSIONS_TEST_RESULTS.md.

This was discovered while attempting to deploy the Erugo Docker container within the Synology NAS environment (DSM 6.2).  I suspect this also fixes issues where the storage directory is an NFS export (have not tried that).  This works perfectly now in Docker environments where permission denied errors had appeared.

// RZA-SF //