### PR TITLE
Fix indefinite service hang under stalled FastCGI requests (#256)

### DIFF
--- a/docker/alpine/Caddyfile
+++ b/docker/alpine/Caddyfile
@@ -70,6 +70,9 @@
         try_files {path} {path}/ /index.php?{query}
         
         # Enable PHP processing
-        php_fastcgi unix//run/php/php-fpm.sock
+        php_fastcgi unix//run/php/php-fpm.sock {
+            read_timeout 310s
+            write_timeout 310s
+        }
     }
 }

--- a/docker/alpine/www.conf
+++ b/docker/alpine/www.conf
@@ -16,6 +16,8 @@ pm.min_spare_servers = 1
 pm.max_spare_servers = 3
 pm.max_requests = 500
 
+request_terminate_timeout = 300s
+
 ; Environment
 env[PATH] = /usr/local/bin:/usr/bin:/bin
 env[APP_ENV] = $APP_ENV


### PR DESCRIPTION
Fixes #256.

Stalled request bodies leave fpm workers blocked forever on FCGI_STDIN while
Caddy waits forever for response headers — no timeout on either side. A few
such requests exhaust the pool and the service hangs until restart.

Changes:
- `www.conf`: add `request_terminate_timeout = 300s` (the fix — poisoned
  workers are now recycled instead of stuck forever)
- `Caddyfile`: add `read_timeout`/`write_timeout 310s` on `php_fastcgi` as a
  backstop (502 instead of an indefinite stall)

Validated with `php-fpm83 -tt` and `caddy validate`, and running in production
on our instance via an equivalent override since the incident.