### PR TITLE
fix(security): clamp stats days parameter to prevent unbounded DB que…

### DIFF
--- a/app/Http/Controllers/StatsController.php
+++ b/app/Http/Controllers/StatsController.php
@@ -108,7 +108,7 @@ class StatsController extends Controller
 
     public function getStats(Request $request)
     {
-        $days = $request->input('days', 30);
+        $days = max(1, min(365, (int) $request->input('days', 30)));
         
         // Storage stats
         $storageStats = $this->getStorageStats();


### PR DESCRIPTION
…ries

GET /api/stats accepts a ?days= parameter that was passed directly to date arithmetic without bounds checking. A very large value (e.g. days=999999) would cause the query to scan the entire downloads table potentially exhausting memory or taking excessive time.

Clamp to the range [1, 365] with an integer cast so the query is always bounded.

Note: this same one-liner is also included in feature/physical-storage as part of that feature's StatsController changes. If that PR is merged first, this fix will already be present and this branch can be skipped.

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //