### PR TITLE
fix(security): validate theme file content and enforce 512 KB size limit

### DIFF
--- a/app/Http/Controllers/ThemesController.php
+++ b/app/Http/Controllers/ThemesController.php
@@ -50,7 +50,7 @@ class ThemesController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'name' => ['required', 'string', 'max:255'],
-            'file' => ['required', 'file'],
+            'file' => ['required', 'file', 'max:512'], // 512 KB limit
         ]);
 
         if ($validator->fails()) {
@@ -66,6 +66,26 @@ class ThemesController extends Controller
         $themeName = $request->input('name');
         $themeFile = $request->file('file');
 
+        // Verify file content is actually JSON (not just a renamed file)
+        $finfo    = new \finfo(FILEINFO_MIME_TYPE);
+        $realMime = $finfo->file($themeFile->getRealPath());
+        if (!in_array($realMime, ['application/json', 'text/plain'], true)) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Theme file must be a JSON file',
+            ], 422);
+        }
+
+        $raw = file_get_contents($themeFile->getRealPath());
+        $themeData = json_decode($raw, true);
+
+        if (!is_array($themeData)) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Invalid theme file: must be a JSON object',
+            ], 422);
+        }
+
         $theme = Theme::where('name', $themeName)->first();
         if ($theme) {
             $themeName = $themeName . ' (custom)';
@@ -74,7 +94,7 @@ class ThemesController extends Controller
         $theme = Theme::create([
             'name' => $themeName,
             'category' => 'custom',
-            'theme' => json_decode(file_get_contents($themeFile), true),
+            'theme' => $themeData,
         ]);
 
         return response()->json([


### PR DESCRIPTION
installCustomTheme() accepted any file upload and called json_decode on it without verifying it was actually JSON. A malformed or oversized file could exhaust memory; a non-JSON file would silently produce a null theme object and be stored.

Fixes:
- Add max:512 (512 KB) to the file validation rule.
- Verify the uploaded file's magic bytes match application/json or text/plain before reading its content.
- Decode the JSON once, validate it is an array, and return HTTP 422 on invalid input rather than storing garbage.
- Pass the already-decoded $themeData to Theme::create() instead of calling json_decode(file_get_contents(...)) a second time.

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //