### PR TITLE
fix(security): verify background upload MIME type from file magic bytes

### DIFF
--- a/app/Http/Controllers/BackgroundsController.php
+++ b/app/Http/Controllers/BackgroundsController.php
@@ -79,6 +79,21 @@ class BackgroundsController extends Controller
 
         try {
             $file = $request->file('background_image');
+
+            // Content-based MIME verification (finfo reads file magic bytes)
+            $finfo    = new \finfo(FILEINFO_MIME_TYPE);
+            $realMime = $finfo->file($file->getRealPath());
+            $allowedMimes = [
+                'image/jpeg', 'image/png', 'image/gif', 'image/webp',
+                'video/mp4', 'video/webm',
+            ];
+            if (!in_array($realMime, $allowedMimes, true)) {
+                return response()->json([
+                    'status' => 'error',
+                    'message' => 'Background file upload failed: unsupported file type',
+                ], 422);
+            }
+
             $fileName = $file->getClientOriginalName();
             $safeFilename = FileHelper::sanitizeFilename($fileName);
             $file->storeAs('', $safeFilename, 'backgrounds');


### PR DESCRIPTION
The background image upload endpoint accepted any file as long as the validator allowed the extension. An attacker could rename a PHP or HTML file to .jpg and upload it as a background.

Add content-based MIME verification using PHP's finfo extension which reads the file's actual magic bytes rather than trusting the client- supplied Content-Type or filename extension. Files that do not match the allowed types (image/jpeg, image/png, image/gif, image/webp, video/mp4, video/webm) are rejected with HTTP 422 before storage.

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //