### PR TITLE
fix(security): strip exception messages from API error responses

### DIFF
--- a/app/Http/Controllers/BackupsController.php
+++ b/app/Http/Controllers/BackupsController.php
@@ -100,7 +100,7 @@ class BackupsController extends Controller
             Log::error('On-demand database backup failed: ' . $e->getMessage());
             return response()->json([
                 'status' => 'error',
-                'message' => 'Failed to create backup: ' . $e->getMessage()
+                'message' => 'Failed to create backup'
             ], 500);
         }
     }

--- a/app/Http/Controllers/TusdHooksController.php
+++ b/app/Http/Controllers/TusdHooksController.php
@@ -166,7 +166,7 @@ class TusdHooksController extends Controller
 
             return response()->json([
                 'ok' => false,
-                'message' => 'Unauthorized: ' . $e->getMessage()
+                'message' => 'Unauthorized'
             ], 401);
         }
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -85,9 +85,10 @@ class UsersController extends Controller
         'message' => 'Provider unlinked successfully'
       ]);
     } catch (\Exception $e) {
+      \Log::error('Failed to unlink provider for user ' . $user->id . ': ' . $e->getMessage());
       return response()->json([
         'status' => 'error',
-        'message' => 'Failed to unlink provider: ' . $e->getMessage()
+        'message' => 'Failed to unlink provider'
       ], 500);
     }
   }


### PR DESCRIPTION
Exception messages returned in HTTP error responses can expose internal
implementation details — file paths, database table names, query fragments,
or server configuration — that are useful to an attacker but irrelevant to
the API caller.

Two controllers were returning raw `$e->getMessage()` in JSON error responses:

- `BackupsController::create()` — returned `"Failed to create backup: {exception}"`
- `TusdHooksController` — returned `"Unauthorized: {exception}"`

Both are now changed to return a generic message string only. The exception
detail is still captured server-side via `Log::error()` for diagnostics.

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //