### PR TITLE
fix(security): remove privileged fields from User mass-assignment allowlist

### DIFF
--- a/app/Http/Controllers/ExternalAuthController.php
+++ b/app/Http/Controllers/ExternalAuthController.php
@@ -313,15 +313,17 @@ class ExternalAuthController extends Controller
      */
     private function createUserFromProvider($authProviderUser)
     {
-        return User::create([
+        $user = User::create([
             'name' => $authProviderUser->name,
             'email' => $authProviderUser->email,
             'password' => bcrypt(bin2hex(random_bytes(32))), // Random password since they'll use SSO
-            'admin' => false,
-            'active' => true,
-            'must_change_password' => false,
-            'is_guest' => false
         ]);
+        $user->admin = false;
+        $user->active = true;
+        $user->must_change_password = false;
+        $user->is_guest = false;
+        $user->save();
+        return $user;
     }
 
     /**

--- a/app/Http/Controllers/ReverseSharesController.php
+++ b/app/Http/Controllers/ReverseSharesController.php
@@ -75,8 +75,9 @@ class ReverseSharesController extends Controller
                 'name' => $request->recipient_name,
                 'email' => Str::random(20), //we don't need a real email for the guest user
                 'password' => Hash::make(Str::random(20)), //set a random password so the user can't login
-                'is_guest' => true
             ]);
+            $guestUser->is_guest = true;
+            $guestUser->save();
             $guestUserId = $guestUser->id;
 
             // Generate a token only for guest users

--- a/app/Http/Controllers/SelfRegistrationController.php
+++ b/app/Http/Controllers/SelfRegistrationController.php
@@ -76,12 +76,13 @@ class SelfRegistrationController extends Controller
                 'email' => $request->email,
                 'name' => $request->name,
                 'password' => Hash::make($request->password),
-                'admin' => false,
-                'active' => false, // Account is inactive until verified
-                'must_change_password' => false,
-                'email_verification_code' => $code,
-                'email_verification_code_expires_at' => $expiresAt,
             ]);
+            $user->admin = false;
+            $user->active = false; // Account is inactive until verified
+            $user->must_change_password = false;
+            $user->email_verification_code = $code;
+            $user->email_verification_code_expires_at = $expiresAt;
+            $user->save();
 
             // Migrate any existing reverse share invites to the new user
             // This is in its own try-catch so it doesn't prevent the verification email from being sent

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -272,7 +272,15 @@ class UsersController extends Controller
     }
 
     try {
-      $user->update($validator->validated());
+      $validated = $validator->validated();
+
+      if (isset($validated['name']))                 $user->name                 = $validated['name'];
+      if (isset($validated['email']))                $user->email                = $validated['email'];
+      if (isset($validated['password']))             $user->password             = $validated['password'];
+      if (isset($validated['admin']))                $user->admin                = $validated['admin'];
+      if (isset($validated['must_change_password'])) $user->must_change_password = $validated['must_change_password'];
+
+      $user->save();
 
       return response()->json([
         'status' => 'success',

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -194,11 +194,12 @@ class UsersController extends Controller
       $user = User::create([
         'email' => $request->email,
         'name' => $request->name,
-        'admin' => $request->admin,
         'password' => Hash::make(Str::random(20)),
-        'active' => true,
-        'must_change_password' => false,
       ]);
+      $user->admin = (bool) $request->admin;
+      $user->active = true;
+      $user->must_change_password = false;
+      $user->save();
 
       // Migrate any existing reverse share invites to the new user
       // This is in its own try-catch so it doesn't prevent the password email from being sent
@@ -443,10 +444,11 @@ class UsersController extends Controller
         'name' => $request->name,
         'email' => $request->email,
         'password' => Hash::make($request->password),
-        'admin' => true,
-        'active' => true,
-        'must_change_password' => false,
       ]);
+      $user->admin = true;
+      $user->active = true;
+      $user->must_change_password = false;
+      $user->save();
 
       return response()->json([
         'status' => 'success',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,12 +23,6 @@ class User extends Authenticatable implements JWTSubject
         'name',
         'email',
         'password',
-        'admin',
-        'active',
-        'must_change_password',
-        'is_guest',
-        'email_verification_code',
-        'email_verification_code_expires_at',
     ];
 
     /**


### PR DESCRIPTION
User::$fillable previously included admin, active, must_change_password, is_guest, and email_verification_code alongside safe fields. Any controller passing request data to User::create() or User::fill() without explicit filtering could allow privilege escalation or account state manipulation.

Fix: Restrict $fillable to ['name', 'email', 'password'] only. All privileged fields are now assigned directly after creation/update, bypassing mass-assignment entirely.

Controllers updated: UsersController, ExternalAuthController, ReverseSharesController, SelfRegistrationController.

Update (2026-07-28):

Note (addressing feedback from @vcazsdk): The original PR had a regression in UsersController::update() — admin and must_change_password were validated but silently dropped because update() goes through mass-assignment which respects $fillable. This has been resolved in the latest commit: all fields in update() now use explicit direct assignment with a single save(), consistent with the create() and createFirstUser() patterns. Password hashing continues to work automatically via the User model's hashed cast.
https://github.com/ErugoOSS/Erugo/pull/265/commits/7470c7d02e5aaf2537b1108c61fca307b737f06a

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //