### PR TITLE
fix(security): add rate limiting to authentication endpoints

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -44,16 +44,16 @@ Route::group([], function ($router) {
 
     //auth
     Route::group(['prefix' => 'auth'], function ($router) {
-        Route::post('login', [AuthController::class, 'login'])->name('auth.login');
+        Route::post('login', [AuthController::class, 'login'])->name('auth.login')->middleware('throttle:10,1');
         Route::post('refresh', [AuthController::class, 'refresh'])->name('auth.refresh');
         Route::post('logout', [AuthController::class, 'logout'])->name('auth.logout');
-        Route::post('forgot-password', [AuthController::class, 'forgotPassword'])->name('auth.forgotPassword');
-        Route::post('reset-password', [AuthController::class, 'resetPassword'])->name('auth.resetPassword');
-        
+        Route::post('forgot-password', [AuthController::class, 'forgotPassword'])->name('auth.forgotPassword')->middleware('throttle:5,5');
+        Route::post('reset-password', [AuthController::class, 'resetPassword'])->name('auth.resetPassword')->middleware('throttle:5,5');
+
         // Self-registration routes
-        Route::post('register', [SelfRegistrationController::class, 'register'])->name('auth.register');
-        Route::post('verify-email', [SelfRegistrationController::class, 'verifyEmail'])->name('auth.verifyEmail');
-        Route::post('resend-verification', [SelfRegistrationController::class, 'resendCode'])->name('auth.resendVerification');
+        Route::post('register', [SelfRegistrationController::class, 'register'])->name('auth.register')->middleware('throttle:5,1');
+        Route::post('verify-email', [SelfRegistrationController::class, 'verifyEmail'])->name('auth.verifyEmail')->middleware('throttle:5,15');
+        Route::post('resend-verification', [SelfRegistrationController::class, 'resendCode'])->name('auth.resendVerification')->middleware('throttle:3,5');
         Route::get('registration-settings', [SelfRegistrationController::class, 'getSettings'])->name('auth.registrationSettings');
     });
 


### PR DESCRIPTION
Unauthenticated auth endpoints had no rate limiting, allowing unlimited credential stuffing, brute-force, and registration spam.

Limits applied (requests, decay minutes):
- POST /auth/login                — throttle:10,1   (10 req/min)
- POST /auth/forgot-password      — throttle:5,5    (5 req/5 min)
- POST /auth/reset-password       — throttle:5,5    (5 req/5 min)
- POST /auth/register             — throttle:5,1    (5 req/min)
- POST /auth/verify-email         — throttle:5,15   (5 req/15 min)
- POST /auth/resend-verification  — throttle:3,5    (3 req/5 min)

Uses Laravel's built-in throttle middleware (RateLimiter).

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //