### PR TITLE
fix(security): sanitize CSS color values to prevent CSS injection

### DIFF
--- a/resources/js/components/settings/branding.vue
+++ b/resources/js/components/settings/branding.vue
@@ -244,33 +244,43 @@ const saveSettings = async () => {
   }
 }
 
-const applySettingsWithoutRefresh = () => {
-  //find the style tag #erugo-css-variables
-  const styleTag = document.getElementById('erugo-css-variables')
-  if (styleTag) {
-    //update the css variables
-    styleTag.innerHTML = `
+const sanitizeCssColor = (value) => {
+  if (typeof value !== 'string') return '#000000'
+  const v = value.trim()
+  if (
+    /^#[0-9a-fA-F]{3,8}$/.test(v) ||
+    /^rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(\s*,\s*[\d.]+)?\s*\)$/.test(v) ||
+    /^hsla?\(\s*\d+\s*,\s*\d+%\s*,\s*\d+%(\s*,\s*[\d.]+)?\s*\)$/.test(v)
+  ) {
+    return v
+  }
+  return '#000000'
+}
+
+const applyCssVariables = (colors) => {
+  const css = `
       :root {
-        --primary-color: ${settings.value.css_primary_color};
-        --secondary-color: ${settings.value.css_secondary_color};
-        --accent-color: ${settings.value.css_accent_color};
-        --accent-color-light: ${settings.value.css_accent_color_light};
-      }
-      `
-  } else {
-    //add the style tag
-    const styleTag = document.createElement('style')
+        --primary-color: ${sanitizeCssColor(colors.primary)};
+        --secondary-color: ${sanitizeCssColor(colors.secondary)};
+        --accent-color: ${sanitizeCssColor(colors.accent)};
+        --accent-color-light: ${sanitizeCssColor(colors.accentLight)};
+      }`
+  let styleTag = document.getElementById('erugo-css-variables')
+  if (!styleTag) {
+    styleTag = document.createElement('style')
     styleTag.id = 'erugo-css-variables'
-    styleTag.innerHTML = `
-      :root {
-        --primary-color: ${settings.value.css_primary_color};
-        --secondary-color: ${settings.value.css_secondary_color};
-        --accent-color: ${settings.value.css_accent_color};
-        --accent-color-light: ${settings.value.css_accent_color_light};
-      }
-      `
     document.head.appendChild(styleTag)
   }
+  styleTag.textContent = css
+}
+
+const applySettingsWithoutRefresh = () => {
+  applyCssVariables({
+    primary: settings.value.css_primary_color,
+    secondary: settings.value.css_secondary_color,
+    accent: settings.value.css_accent_color,
+    accentLight: settings.value.css_accent_color_light,
+  })
 
   //update the logo width
   const logo = document.getElementById('logo')


### PR DESCRIPTION
The branding settings panel applied user-controlled color values directly into a <style> tag via innerHTML, allowing an admin to inject arbitrary CSS (e.g. expressions, url() calls, or closing the :root block and inserting new rules).

Fixes:
- Add sanitizeCssColor() which validates the value against hex/rgb/hsl patterns and returns '#000000' for anything that does not match, preventing injection through colour inputs.
- Replace innerHTML with textContent so the string is never parsed as HTML; the content is CSS text only.
- Refactor the duplicate create/update branches into a single applyCssVariables(colors) helper.

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //