### PR TITLE
fix(security): sanitize markdown output and SVG provider icons (XSS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "vue": "^3.5.13",
     "vue-codemirror": "^6.1.1",
     "vue-color-kit": "^1.0.6",
-    "vue-toastification": "^2.0.0-rc.5"
+    "vue-toastification": "^2.0.0-rc.5",
+    "dompurify": "^3.2.6"
   },
   "tolgee": {
     "apiUrl": "https://toglee.yixe.co.uk",

--- a/resources/js/components/MarkdownModal.vue
+++ b/resources/js/components/MarkdownModal.vue
@@ -2,6 +2,7 @@
 import { ref, watch, computed } from 'vue'
 import { CircleX, FileWarning } from 'lucide-vue-next'
 import { useTolgee } from '@tolgee/vue'
+import DOMPurify from 'dompurify'
 
 const props = defineProps({
   topic: {
@@ -69,21 +70,24 @@ const parseMarkdown = async (text) => {
     return placeholder
   })
   
-  // Headers
-  text = text.replace(/^### (.*$)/gim, '<h3>$1</h3>')
-  text = text.replace(/^## (.*$)/gim, '<h2>$1</h2>')
-  text = text.replace(/^# (.*$)/gim, '<h1>$1</h1>')
-  
+  // Headers — escape text content before wrapping
+  text = text.replace(/^### (.*$)/gim, (_, t) => `<h3>${escapeHtml(t)}</h3>`)
+  text = text.replace(/^## (.*$)/gim, (_, t) => `<h2>${escapeHtml(t)}</h2>`)
+  text = text.replace(/^# (.*$)/gim, (_, t) => `<h1>${escapeHtml(t)}</h1>`)
+
   // Bold and italic
   text = text.replace(/\*\*\*(.*?)\*\*\*/g, '<strong><em>$1</em></strong>')
   text = text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
   text = text.replace(/\*(.*?)\*/g, '<em>$1</em>')
-  
-  // Inline code
-  text = text.replace(/`([^`]+)`/g, '<code>$1</code>')
-  
-  // Links
-  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
+
+  // Inline code — escape content
+  text = text.replace(/`([^`]+)`/g, (_, code) => `<code>${escapeHtml(code)}</code>`)
+
+  // Links — block javascript:/data: URLs; escape link text
+  text = text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, url) => {
+    const safeUrl = /^(javascript|data|vbscript):/i.test(url.trim()) ? '#' : url
+    return `<a href="${escapeHtml(safeUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(label)}</a>`
+  })
   
   // Process lists - collect consecutive list items
   const lines = text.split('\n')
@@ -148,7 +152,11 @@ const parseMarkdown = async (text) => {
     result = result.replace(`___CODEBLOCK_${index}___`, block)
   })
   
-  return result
+  return DOMPurify.sanitize(result, {
+    ALLOWED_TAGS: ['h1', 'h2', 'h3', 'strong', 'em', 'code', 'pre', 'p', 'ul', 'li', 'a', 'br'],
+    ALLOWED_ATTR: ['href', 'target', 'rel', 'class'],
+    ALLOW_DATA_ATTR: false,
+  })
 }
 
 const escapeHtml = (text) => {

--- a/resources/js/components/auth.vue
+++ b/resources/js/components/auth.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
+import DOMPurify from 'dompurify'
 import { getApiUrl } from '../utils'
 import { useToast } from 'vue-toastification'
 import { domData } from '../domData'
@@ -77,7 +78,10 @@ onMounted(async () => {
   attemptRefresh()
 
   getAvailableAuthProviders().then((data) => {
-    authProviders.value = data
+    authProviders.value = data.map((p) => ({
+      ...p,
+      icon: p.icon ? DOMPurify.sanitize(p.icon, { USE_PROFILES: { svg: true, svgFilters: true } }) : null
+    }))
   })
 
   // Check if self-registration is enabled
@@ -456,7 +460,7 @@ const switchToLogin = () => {
           <div class="col-6 pe-1 ps-1 mb-2" v-for="provider in authProviders" :key="provider.id">
             <button class="block secondary provider-button" @click="attemptAuthProviderLogin(provider.id)">
               <Fingerprint v-if="!provider.icon" />
-              <svg v-else v-html="provider.icon" class="custom"></svg>
+              <svg v-else v-html="DOMPurify.sanitize(provider.icon, { USE_PROFILES: { svg: true } })" class="custom"></svg>
               {{ provider.name }}
             </button>
           </div>


### PR DESCRIPTION
**MarkdownModal — markdown XSS**
- Import DOMPurify; wrap the final rendered HTML in DOMPurify.sanitize() with an explicit ALLOWED_TAGS / ALLOWED_ATTR allowlist so unexpected tags or attributes injected by crafted markdown content are stripped.
- Escape header text, inline-code content, and link labels with escapeHtml() before they are wrapped in HTML tags, preventing raw HTML injection through those elements.
- Block javascript:, data:, and vbscript: URL schemes in link hrefs.

**auth.vue — SVG provider icon XSS (login screen)**
- Auth provider icons rendered with v-html on the login page were not sanitized, allowing a malicious admin to inject arbitrary HTML/JS via a crafted SVG icon.
- Sanitize at load time (map over providers array) and at render time using DOMPurify with the svg + svgFilters profile, consistent with the fix already applied to myProfile.vue and system.vue.

**package.json** — add dompurify ^3.2.6 dependency.

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //