### PR TITLE
fix(security): sanitize provider.icon SVG before v-html render

### DIFF
--- a/resources/js/components/auth.vue
+++ b/resources/js/components/auth.vue
@@ -456,7 +456,7 @@ const switchToLogin = () => {
           <div class="col-6 pe-1 ps-1 mb-2" v-for="provider in authProviders" :key="provider.id">
             <button class="block secondary provider-button" @click="attemptAuthProviderLogin(provider.id)">
               <Fingerprint v-if="!provider.icon" />
-              <svg v-else v-html="provider.icon" class="custom"></svg>
+              <svg v-else v-html="DOMPurify.sanitize(provider.icon, { USE_PROFILES: { svg: true } })" class="custom"></svg>
               {{ provider.name }}
             </button>
           </div>

--- a/resources/js/components/settings/myProfile.vue
+++ b/resources/js/components/settings/myProfile.vue
@@ -252,7 +252,7 @@ const handleUnlinkProvider = async (provider) => {
                     <div class="col-auto">
                       <div class="icon">
                         <Fingerprint v-if="!provider.icon" />
-                        <svg v-else v-html="provider.icon" class="custom"></svg>
+                        <svg v-else v-html="DOMPurify.sanitize(provider.icon, { USE_PROFILES: { svg: true } })" class="custom"></svg>
                       </div>
                     </div>
                     <div class="col">

--- a/resources/js/components/settings/system.vue
+++ b/resources/js/components/settings/system.vue
@@ -1007,7 +1007,7 @@ const handleDeleteAuthProvider = async (id) => {
                       <div class="col-auto">
                         <div class="icon">
                           <Fingerprint v-if="!authProvider.icon" />
-                          <svg v-else v-html="authProvider.icon" class="custom"></svg>
+                          <svg v-else v-html="DOMPurify.sanitize(authProvider.icon, { USE_PROFILES: { svg: true } })" class="custom"></svg>
                         </div>
                       </div>
                       <div class="col">


### PR DESCRIPTION
Three components rendered auth provider icons via v-html on a bare <svg> element without sanitization, allowing a stored-XSS payload in the icon field (admin-controlled) to execute in any session that loaded the page.

Apply DOMPurify.sanitize() with USE_PROFILES: { svg: true } at the point of render in auth.vue, myProfile.vue, and system.vue. DOMPurify is already a project dependency and imported in all three files.

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //