### PR TITLE
fix(security): guard admin-only settings tabs against stale URL hash …

### DIFF
--- a/resources/js/components/settings.vue
+++ b/resources/js/components/settings.vue
@@ -91,13 +91,20 @@ const clickOutside = (e) => {
   }
 }
 
+const ADMIN_TABS = ['stats', 'branding', 'system', 'emailTemplates', 'users', 'allShares', 'backups']
+
 const setActiveTab = (tab, options = {}) => {
+  // Silently block non-admins from landing on admin-only tabs (e.g. via stale URL hash)
+  if (ADMIN_TABS.includes(tab) && !store.isAdmin()) {
+    activeTab.value = 'myShares'
+    return
+  }
   const { updateUrl = true } = options
   activeTab.value = tab
   if (tab === 'allShares' && allSharesUsers.value.length === 0) {
     loadAllSharesUsers()
   }
-  
+
   // Update URL hash with the new tab
   if (updateUrl) {
     updateUrlHash(tab)


### PR DESCRIPTION
…navigation

Non-admin users arriving via a URL hash left from a previous admin session (e.g. #settings/allShares) were silently navigated to admin-only tabs, causing them to see all-shares data and triggering 403 responses on admin-only API calls. setActiveTab() now redirects non-admins to myShares when any admin tab is requested.

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //