### PR TITLE
fix(security): restrict system.smtp settings group to admin-only access

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\Setting;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
@@ -11,6 +12,29 @@ use App\Utils\FileHelper;
 use App\Services\SettingsService;
 class SettingsController extends Controller
 {
+    /**
+     * Groups whose settings may only be read by administrators.
+     * Restricted to groups that contain actual credentials — specifically
+     * SMTP server credentials in system.smtp. Other system.* sub-groups
+     * (system.shares, system.auth, system.emails, etc.) hold non-sensitive
+     * configuration that authenticated non-admin users legitimately need to
+     * read (e.g. share limits, self-registration flags).
+     */
+    private const ADMIN_ONLY_GROUPS = ['system.smtp'];
+
+    /**
+     * Return true when the given group string falls under an admin-only prefix.
+     */
+    private function groupRequiresAdmin(string $group): bool
+    {
+        foreach (self::ADMIN_ONLY_GROUPS as $restricted) {
+            if ($group === $restricted || str_starts_with($group, $restricted . '.')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public function write(Request $request)
     {
         $request->validate([
@@ -73,6 +97,14 @@ class SettingsController extends Controller
                 'message' => 'Setting not found',
             ], 404);
         }
+
+        if ($this->groupRequiresAdmin($setting->group) && !Auth::user()?->admin) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Forbidden',
+            ], 403);
+        }
+
         return response()->json([
             'status' => 'success',
             'data' => [
@@ -83,6 +115,14 @@ class SettingsController extends Controller
 
     public function readGroup(Request $request, $group)
     {
+        // Strip trailing wildcard so we can check the base group name
+        $baseGroup = rtrim($group, '.*');
+        if ($this->groupRequiresAdmin($baseGroup) && !Auth::user()?->admin) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Forbidden',
+            ], 403);
+        }
 
         $query = Setting::query();
 
@@ -159,7 +199,7 @@ class SettingsController extends Controller
             Log::error('Logo upload error: ' . $e->getMessage());
             return response()->json([
                 'status' => 'error',
-                'message' => 'Failed to save logo: ' . $e->getMessage(),
+                'message' => 'Failed to save logo',
             ], 500);
         }
     }
@@ -199,7 +239,7 @@ class SettingsController extends Controller
             Log::error('Logo reset error: ' . $e->getMessage());
             return response()->json([
                 'status' => 'error',
-                'message' => 'Failed to reset logo: ' . $e->getMessage(),
+                'message' => 'Failed to reset logo',
             ], 500);
         }
     }


### PR DESCRIPTION
GET /api/settings/{key} and GET /api/settings/group/{group} were protected only by auth middleware, allowing any logged-in user to read SMTP credentials and other system secrets.

Added groupRequiresAdmin() guard returning HTTP 403 to non-admins for the system.smtp group (the only group containing actual credentials). Broader prefixes such as 'system' are intentionally excluded — other system.* subgroups (shares, auth flags, etc.) contain non-sensitive configuration that regular users legitimately need to read.

Also removes $e->getMessage() from logo upload/reset error responses (information disclosure).

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //