### PR TITLE
fix(security): reject invalid credentials and refuse login for disabl…

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -39,9 +39,22 @@ class AuthController extends Controller
 
         $credentials = $request->only('email', 'password');
 
-        Auth::attempt($credentials);
+        if (!Auth::attempt($credentials)) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Unauthorized'
+            ], 401);
+        }
+
         $user = Auth::user();
 
+        if (!$user->active) {
+            Auth::logout();
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Account is disabled'
+            ], 403);
+        }
 
         return $this->respondWithToken($user);
     }
@@ -66,6 +79,13 @@ class AuthController extends Controller
                 'status' => 'error',
                 'message' => 'Unauthorized'
             ], 401);
+        }
+
+        if (!$user->active) {
+            return response()->json([
+                'status' => 'error',
+                'message' => 'Account is disabled'
+            ], 403);
         }
 
         return $this->respondWithToken($user);


### PR DESCRIPTION
…ed accounts

AuthController::login() called Auth::attempt() without checking its return value, so invalid credentials silently passed through and the $user->active flag was never consulted. Inactive users could log in and receive a JWT.

- login() now returns HTTP 401 on failed credentials
- login() and refresh() both return HTTP 403 if the account is inactive

Discovered while security review conducted during feature branch work on my local repo.

// RZA-SF //