### PR TITLE
feat: complete share lifecycle management — extend, pending deletion, admin override, purge

### DIFF
--- a/app/Http/Controllers/SharesController.php
+++ b/app/Http/Controllers/SharesController.php
@@ -702,8 +702,8 @@ class SharesController extends Controller
     }
 
     $confirmation = $request->input('confirmation');
-    if (strtolower(trim($confirmation ?? '')) !== 'delete') {
-      return response()->json(['status' => 'error', 'message' => 'Confirmation required — type "delete" to confirm'], 422);
+    if (trim($confirmation ?? '') !== 'DELETE') {
+      return response()->json(['status' => 'error', 'message' => 'Confirmation required — type DELETE (uppercase) to confirm'], 422);
     }
 
     $share = Share::where('id', $shareId)->first();

--- a/app/Http/Controllers/SharesController.php
+++ b/app/Http/Controllers/SharesController.php
@@ -42,6 +42,13 @@ class SharesController extends Controller
       ], 404);
     }
 
+    if (in_array($share->status, ['pending_deletion', 'deleted'])) {
+      return response()->json([
+        'status' => 'error',
+        'message' => 'Share not found'
+      ], 404);
+    }
+
     if ($share->expires_at < Carbon::now()) {
       return response()->json([
         'status' => 'error',
@@ -163,6 +170,10 @@ class SharesController extends Controller
 
     $share = Share::where('long_id', $shareId)->with('files')->first();
     if (!$share) {
+      return redirect()->to('/shares/' . $shareId);
+    }
+
+    if (in_array($share->status, ['pending_deletion', 'deleted'])) {
       return redirect()->to('/shares/' . $shareId);
     }
 
@@ -602,6 +613,81 @@ class SharesController extends Controller
     ]);
   }
 
+
+  /**
+   * Mark a share as pending deletion. The share link stops working immediately.
+   * Files are cleaned up when an admin runs "Delete immediately" (F5) or the
+   * scheduled cleanup job processes pending_deletion shares.
+   * Both the share owner and admins may call this.
+   */
+  public function requestDeletion($shareId)
+  {
+    $user = Auth::user();
+    if (!$user) {
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+    }
+
+    $share = Share::where('id', $shareId)->first();
+    if (!$share) {
+      return response()->json(['status' => 'error', 'message' => 'Share not found'], 404);
+    }
+
+    if (!$this->canManageShare($share, $user)) {
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+    }
+
+    if (in_array($share->status, ['pending_deletion', 'deleted'])) {
+      return response()->json(['status' => 'error', 'message' => 'Share is already pending deletion or deleted'], 422);
+    }
+
+    $share->status = 'pending_deletion';
+    $share->deletion_requested_at = Carbon::now();
+    $share->deletion_requested_by = $user->admin ? 'admin' : 'user';
+    $share->save();
+
+    return response()->json([
+      'status' => 'success',
+      'message' => 'Share marked for deletion',
+      'data' => ['share' => $share]
+    ]);
+  }
+
+  /**
+   * Undo a pending deletion request. Restores the share to 'ready' status
+   * so the link becomes active again. Only valid while status is still
+   * 'pending_deletion' (i.e. before files have been cleaned up).
+   */
+  public function undoDeletion($shareId)
+  {
+    $user = Auth::user();
+    if (!$user) {
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+    }
+
+    $share = Share::where('id', $shareId)->first();
+    if (!$share) {
+      return response()->json(['status' => 'error', 'message' => 'Share not found'], 404);
+    }
+
+    if (!$this->canManageShare($share, $user)) {
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+    }
+
+    if ($share->status !== 'pending_deletion') {
+      return response()->json(['status' => 'error', 'message' => 'Share is not pending deletion'], 422);
+    }
+
+    $share->status = 'ready';
+    $share->deletion_requested_at = null;
+    $share->deletion_requested_by = null;
+    $share->save();
+
+    return response()->json([
+      'status' => 'success',
+      'message' => 'Share deletion undone',
+      'data' => ['share' => $share]
+    ]);
+  }
 
   public function generateLongId()
   {

--- a/app/Http/Controllers/SharesController.php
+++ b/app/Http/Controllers/SharesController.php
@@ -529,9 +529,19 @@ class SharesController extends Controller
       return response()->json(['status' => 'success', 'message' => 'Share set to no expiration', 'data' => ['share' => $share]]);
     }
 
-    // Admin can set a specific date
-    if ($user->admin && $request->filled('expires_at')) {
+    // Any user can set a specific date; non-admins are subject to max_expiry_time
+    if ($request->filled('expires_at')) {
       $newExpiry = Carbon::parse($request->input('expires_at'));
+      if (!$user->admin && $maxExpiryDays !== null) {
+        $maxAllowed = Carbon::now()->addDays((int) $maxExpiryDays);
+        if ($newExpiry > $maxAllowed) {
+          return response()->json([
+            'status'  => 'error',
+            'message' => 'Date exceeds maximum allowed expiry time',
+            'data'    => ['max_expiry_days' => (int) $maxExpiryDays]
+          ], 422);
+        }
+      }
       $share->expires_at = $newExpiry;
       $share->save();
       return response()->json(['status' => 'success', 'message' => 'Share extended', 'data' => ['share' => $share]]);

--- a/app/Http/Controllers/SharesController.php
+++ b/app/Http/Controllers/SharesController.php
@@ -653,7 +653,7 @@ class SharesController extends Controller
         ->orWhereHas('invite', function ($q) use ($user) {
           $q->where('user_id', $user->id);
         });
-    })->where('expires_at', '<', Carbon::now())->get();
+    })->where('status', 'pending_deletion')->get();
     cleanSpecificShares::dispatch($shares->pluck('id')->toArray(), $user->id);
 
     return response()->json([
@@ -788,6 +788,44 @@ class SharesController extends Controller
       'status' => 'success',
       'message' => 'Share deleted immediately',
       'data' => ['share' => $share]
+    ]);
+  }
+
+  /**
+   * Permanently remove the DB record (and any remaining child rows) for a share
+   * that has already been soft-deleted. Files have already been cleaned up by
+   * the deletion flow; this just removes the DB row.
+   * Available to the share owner or any admin.
+   */
+  public function purgeShare($shareId)
+  {
+    $user = Auth::user();
+    if (!$user) {
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+    }
+
+    $share = Share::where('id', $shareId)->first();
+    if (!$share) {
+      return response()->json(['status' => 'error', 'message' => 'Share not found'], 404);
+    }
+
+    if (!$this->canManageShare($share, $user)) {
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+    }
+
+    if ($share->status !== 'deleted') {
+      return response()->json(['status' => 'error', 'message' => 'Only shares with status "deleted" can be purged'], 422);
+    }
+
+    // Delete all child rows before removing the share to avoid FK constraint violations.
+    // Neither downloads.share_id nor files.share_id have ON DELETE CASCADE.
+    Download::where('share_id', $share->id)->delete();
+    $share->files()->delete();
+    $share->delete();
+
+    return response()->json([
+      'status' => 'success',
+      'message' => 'Share record removed',
     ]);
   }
 

--- a/app/Http/Controllers/SharesController.php
+++ b/app/Http/Controllers/SharesController.php
@@ -689,6 +689,56 @@ class SharesController extends Controller
     ]);
   }
 
+  /**
+   * Admin: immediately delete a share's files and mark it as deleted.
+   * Only valid when the share is in pending_deletion, expired, or deleted-awaiting-cleanup state.
+   * Requires a typed confirmation phrase in the request body.
+   */
+  public function deleteImmediately($shareId, Request $request)
+  {
+    $user = Auth::user();
+    if (!$user || !$user->admin) {
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+    }
+
+    $confirmation = $request->input('confirmation');
+    if (strtolower(trim($confirmation ?? '')) !== 'delete') {
+      return response()->json(['status' => 'error', 'message' => 'Confirmation required — type "delete" to confirm'], 422);
+    }
+
+    $share = Share::where('id', $shareId)->first();
+    if (!$share) {
+      return response()->json(['status' => 'error', 'message' => 'Share not found'], 404);
+    }
+
+    // Only allow immediate deletion for shares in an actionable state
+    $actionableStatuses = ['pending_deletion', 'deleted'];
+    $isExpired = $share->expires_at !== null && $share->expires_at < Carbon::now();
+
+    if (!in_array($share->status, $actionableStatuses) && !$isExpired) {
+      return response()->json([
+        'status' => 'error',
+        'message' => 'Share must be pending deletion or expired before it can be immediately deleted'
+      ], 422);
+    }
+
+    if ($share->status === 'deleted') {
+      return response()->json(['status' => 'error', 'message' => 'Share is already deleted'], 422);
+    }
+
+    $cleaned = $share->cleanFiles();
+
+    if (!$cleaned) {
+      return response()->json(['status' => 'error', 'message' => 'Failed to delete share files'], 500);
+    }
+
+    return response()->json([
+      'status' => 'success',
+      'message' => 'Share deleted immediately',
+      'data' => ['share' => $share]
+    ]);
+  }
+
   public function generateLongId()
   {
     $settingsService = new SettingsService();

--- a/app/Http/Controllers/SharesController.php
+++ b/app/Http/Controllers/SharesController.php
@@ -503,38 +503,80 @@ class SharesController extends Controller
     ]);
   }
 
-  public function extend($shareId)
+  public function extend($shareId, Request $request)
   {
-
     $user = Auth::user();
     if (!$user) {
-      return response()->json([
-        'status' => 'error',
-        'message' => 'Unauthorized'
-      ], 401);
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
     }
+
     $share = Share::where('id', $shareId)->first();
     if (!$share) {
-      return response()->json([
-        'status' => 'error',
-        'message' => 'Share not found'
-      ], 404);
+      return response()->json(['status' => 'error', 'message' => 'Share not found'], 404);
     }
+
     if (!$this->canManageShare($share, $user)) {
-      return response()->json([
-        'status' => 'error',
-        'message' => 'Unauthorized'
-      ], 401);
+      return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
     }
-    $share->expires_at = Carbon::now()->addDays(7);
+
+    $settingsService = new SettingsService();
+    $maxExpiryDays = $settingsService->get('max_expiry_time'); // null = no limit configured
+
+    // Admin can set unlimited (null expires_at)
+    if ($user->admin && $request->boolean('unlimited')) {
+      $share->expires_at = null;
+      $share->save();
+      return response()->json(['status' => 'success', 'message' => 'Share set to no expiration', 'data' => ['share' => $share]]);
+    }
+
+    // Admin can set a specific date
+    if ($user->admin && $request->filled('expires_at')) {
+      $newExpiry = Carbon::parse($request->input('expires_at'));
+      $share->expires_at = $newExpiry;
+      $share->save();
+      return response()->json(['status' => 'success', 'message' => 'Share extended', 'data' => ['share' => $share]]);
+    }
+
+    // Relative extension: amount + unit (default: 7 days, matching original behaviour)
+    $amount = (int) $request->input('amount', 7);
+    $unit   = $request->input('unit', 'days');
+
+    if ($amount < 1) {
+      return response()->json(['status' => 'error', 'message' => 'Amount must be at least 1'], 422);
+    }
+
+    if (!in_array($unit, ['days', 'weeks', 'months'])) {
+      return response()->json(['status' => 'error', 'message' => 'Unit must be days, weeks, or months'], 422);
+    }
+
+    // Base: current expiry or now, whichever is later (fixes bug where extending
+    // a far-future share from now() would shorten it)
+    $base = ($share->expires_at !== null && $share->expires_at > Carbon::now())
+      ? $share->expires_at
+      : Carbon::now();
+
+    $newExpiry = match ($unit) {
+      'weeks'  => $base->copy()->addWeeks($amount),
+      'months' => $base->copy()->addMonths($amount),
+      default  => $base->copy()->addDays($amount),
+    };
+
+    // Enforce max_expiry_time for non-admin users
+    if (!$user->admin && $maxExpiryDays !== null) {
+      $maxAllowed = Carbon::now()->addDays((int) $maxExpiryDays);
+      if ($newExpiry > $maxAllowed) {
+        return response()->json([
+          'status'  => 'error',
+          'message' => 'Extension would exceed maximum allowed expiry time',
+          'data'    => ['max_expiry_days' => (int) $maxExpiryDays]
+        ], 422);
+      }
+    }
+
+    $share->expires_at = $newExpiry;
     $share->save();
-    return response()->json([
-      'status' => 'success',
-      'message' => 'Share extended',
-      'data' => [
-        'share' => $share
-      ]
-    ]);
+
+    return response()->json(['status' => 'success', 'message' => 'Share extended', 'data' => ['share' => $share]]);
   }
 
   public function setDownloadLimit($shareId, Request $request)

--- a/app/Jobs/cleanExpiredShares.php
+++ b/app/Jobs/cleanExpiredShares.php
@@ -23,8 +23,18 @@ class cleanExpiredShares implements ShouldQueue
     {
         Log::info('Cleaning expired shares');
         $startTime = microtime(true);
-        $shares = Share::readyForCleaning()->get();
-        Log::info('Found ' . $shares->count() . ' shares to clean');
+
+        // Shares past the cleanup window (existing behaviour)
+        $expiredShares = Share::readyForCleaning()->get();
+
+        // Shares explicitly marked for deletion by a user or admin (F4/F5)
+        $pendingShares = Share::where('status', 'pending_deletion')->get();
+
+        $shares = $expiredShares->merge($pendingShares)->unique('id');
+
+        Log::info('Found ' . $shares->count() . ' shares to clean (' .
+            $expiredShares->count() . ' expired, ' . $pendingShares->count() . ' pending deletion)');
+
         foreach ($shares as $share) {
             Log::info('Cleaning share ' . $share->id);
             $share->cleanFiles();

--- a/app/Jobs/sendDeletionWarningEmails.php
+++ b/app/Jobs/sendDeletionWarningEmails.php
@@ -39,6 +39,7 @@ class sendDeletionWarningEmails implements ShouldQueue
 
     $shares = Share::where('expires_at', '<=', now()->subDays($clean_files_after_days - $deletion_warning_days))
       ->where('sent_deletion_warning', false)
+      ->whereNotIn('status', ['pending_deletion', 'deleted'])
       ->get();
 
     foreach ($shares as $share) {

--- a/app/Jobs/sendExpiredWarningEmails.php
+++ b/app/Jobs/sendExpiredWarningEmails.php
@@ -36,6 +36,7 @@ class sendExpiredWarningEmails implements ShouldQueue
 
     $shares = Share::where('expires_at', '<', now())
       ->where('sent_expired', false)
+      ->whereNotIn('status', ['pending_deletion', 'deleted'])
       ->get();
 
     foreach ($shares as $share) {

--- a/app/Jobs/sendExpiryWarningEmails.php
+++ b/app/Jobs/sendExpiryWarningEmails.php
@@ -38,6 +38,7 @@ class sendExpiryWarningEmails implements ShouldQueue
         $shares = Share::where('expires_at', '<', now()->addDays($expiry_warning_days))
             ->where('expires_at', '>', now())
             ->where('sent_expiry_warning', false)
+            ->whereNotIn('status', ['pending_deletion', 'deleted'])
             ->get();
 
         foreach ($shares as $share) {

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -65,11 +65,18 @@ class Share extends Model
 
   function getExpiredAttribute()
   {
+    if ($this->expires_at === null) {
+      return false; // null = no expiration (admin unlimited)
+    }
     return $this->expires_at < now()->addMinutes(1);
   }
 
   function getDeletesAtAttribute()
   {
+    if ($this->expires_at === null) {
+      return null; // no expiration = no scheduled cleanup
+    }
+
     $cleanFilesAfterDays = Setting::where('key', 'clean_files_after_days')->first();
 
     if (!$cleanFilesAfterDays) {

--- a/app/Models/Share.php
+++ b/app/Models/Share.php
@@ -24,18 +24,22 @@ class Share extends Model
     'require_email',
     'expires_at',
     'status',
-    'password'
+    'password',
+    'deletion_requested_at',
+    'deletion_requested_by',
   ];
 
   protected $casts = [
     'expires_at' => 'datetime',
     'deletes_at' => 'datetime',
+    'deletion_requested_at' => 'datetime',
   ];
 
   protected $appends = [
     'expired',
     'deletes_at',
-    'deleted'
+    'deleted',
+    'pending_deletion',
   ];
 
   protected $hidden = [
@@ -88,6 +92,11 @@ class Share extends Model
   function getDeletedAttribute()
   {
     return $this->status == 'deleted';
+  }
+
+  function getPendingDeletionAttribute()
+  {
+    return $this->status === 'pending_deletion';
   }
 
   public function scopeReadyForCleaning($query)

--- a/database/migrations/2026_07_11_200000_add_pending_deletion_to_shares_table.php
+++ b/database/migrations/2026_07_11_200000_add_pending_deletion_to_shares_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('shares', function (Blueprint $table) {
+            // Tracks when a user or admin requested early deletion of a share.
+            // Status 'pending_deletion' is the in-flight state between request and
+            // actual file cleanup. Share link stops working immediately; files are
+            // cleaned on the next admin action or cleanup job run.
+            $table->timestamp('deletion_requested_at')->nullable()->after('status');
+            $table->string('deletion_requested_by', 10)->nullable()->after('deletion_requested_at'); // 'user' | 'admin'
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('shares', function (Blueprint $table) {
+            $table->dropColumn(['deletion_requested_at', 'deletion_requested_by']);
+        });
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,7 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -976,6 +976,21 @@ export const requestShareDeletion = async (id) => {
   return data.data.share
 }
 
+export const deleteShareImmediately = async (id, confirmation) => {
+  const response = await fetchWithAuth(`${apiUrl}/api/shares/${id}/delete-immediately`, {
+    method: 'POST',
+    headers: {
+      ...addJsonHeader()
+    },
+    body: JSON.stringify({ confirmation })
+  })
+  const data = await response.json()
+  if (!response.ok) {
+    throw new Error(data.message)
+  }
+  return data.data.share
+}
+
 export const undoShareDeletion = async (id) => {
   const response = await fetchWithAuth(`${apiUrl}/api/shares/${id}/undo-deletion`, {
     method: 'POST',

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -962,6 +962,34 @@ export const pruneExpiredShares = async () => {
   return data.data.shares
 }
 
+export const requestShareDeletion = async (id) => {
+  const response = await fetchWithAuth(`${apiUrl}/api/shares/${id}/request-deletion`, {
+    method: 'POST',
+    headers: {
+      ...addJsonHeader()
+    }
+  })
+  const data = await response.json()
+  if (!response.ok) {
+    throw new Error(data.message)
+  }
+  return data.data.share
+}
+
+export const undoShareDeletion = async (id) => {
+  const response = await fetchWithAuth(`${apiUrl}/api/shares/${id}/undo-deletion`, {
+    method: 'POST',
+    headers: {
+      ...addJsonHeader()
+    }
+  })
+  const data = await response.json()
+  if (!response.ok) {
+    throw new Error(data.message)
+  }
+  return data.data.share
+}
+
 export const getShare = async (id) => {
   const response = await fetchWithAuth(`${apiUrl}/api/shares/${id}`, {
     method: 'GET',

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -917,12 +917,13 @@ export const expireShare = async (id) => {
   return data.data.share
 }
 
-export const extendShare = async (id) => {
+export const extendShare = async (id, payload = {}) => {
   const response = await fetchWithAuth(`${apiUrl}/api/shares/${id}/extend`, {
     method: 'POST',
     headers: {
       ...addJsonHeader()
-    }
+    },
+    body: JSON.stringify(payload)
   })
   const data = await response.json()
   if (!response.ok) {

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -1006,6 +1006,20 @@ export const undoShareDeletion = async (id) => {
   return data.data.share
 }
 
+export const purgeShare = async (id) => {
+  const response = await fetchWithAuth(`${apiUrl}/api/shares/${id}`, {
+    method: 'DELETE',
+    headers: {
+      ...addJsonHeader()
+    }
+  })
+  const data = await response.json()
+  if (!response.ok) {
+    throw new Error(data.message)
+  }
+  return data
+}
+
 export const getShare = async (id) => {
   const response = await fetchWithAuth(`${apiUrl}/api/shares/${id}`, {
     method: 'GET',

--- a/resources/js/components/ExtendShareModal.vue
+++ b/resources/js/components/ExtendShareModal.vue
@@ -3,6 +3,7 @@ import { ref, computed } from 'vue'
 import { extendShare } from '../api'
 import { useToast } from 'vue-toastification'
 import { CalendarPlus, X } from 'lucide-vue-next'
+import { domData } from '../domData'
 
 const props = defineProps({
   share: {
@@ -14,6 +15,9 @@ const props = defineProps({
     default: false
   }
 })
+
+// max_expiry_time is in the page's initial settings (null = unlimited for admins)
+const maxExpiryDays = props.isAdmin ? null : (domData().max_expiry_time || null)
 
 const emit = defineEmits(['close', 'extended'])
 
@@ -37,6 +41,13 @@ const minDate = computed(() => {
   const tomorrow = new Date()
   tomorrow.setDate(tomorrow.getDate() + 1)
   return tomorrow.toISOString().split('T')[0]
+})
+
+const maxDate = computed(() => {
+  if (!maxExpiryDays) return null
+  const d = new Date()
+  d.setDate(d.getDate() + parseInt(maxExpiryDays))
+  return d.toISOString().split('T')[0]
 })
 
 const handleSubmit = async () => {
@@ -89,10 +100,10 @@ const handleSubmit = async () => {
         <strong>{{ currentExpiry }}</strong>
       </div>
 
-      <div v-if="isAdmin" class="mode-tabs">
+      <div class="mode-tabs">
         <button :class="{ active: mode === 'relative' }" @click="mode = 'relative'">Extend by</button>
         <button :class="{ active: mode === 'date' }" @click="mode = 'date'">Set date</button>
-        <button :class="{ active: mode === 'unlimited' }" @click="mode = 'unlimited'">No expiration</button>
+        <button v-if="isAdmin" :class="{ active: mode === 'unlimited' }" @click="mode = 'unlimited'">No expiration</button>
       </div>
 
       <div class="modal-body">
@@ -112,14 +123,16 @@ const handleSubmit = async () => {
           </select>
         </div>
 
-        <!-- Admin: specific date -->
+        <!-- Specific date (all users; max constrained for non-admins) -->
         <div v-else-if="mode === 'date'" class="date-picker">
           <input
             type="date"
             v-model="specificDate"
             :min="minDate"
+            :max="maxDate || undefined"
             class="date-input"
           />
+          <p v-if="maxDate" class="date-hint">Max: {{ maxDate }}</p>
         </div>
 
         <!-- Admin: no expiration -->
@@ -271,6 +284,13 @@ const handleSubmit = async () => {
 }
 
 .date-picker {
+  .date-hint {
+    margin: 6px 0 0;
+    font-size: 0.75rem;
+    color: var(--panel-section-text-color);
+    opacity: 0.6;
+  }
+
   .date-input {
     width: 100%;
     padding: 8px 12px;

--- a/resources/js/components/ExtendShareModal.vue
+++ b/resources/js/components/ExtendShareModal.vue
@@ -1,0 +1,303 @@
+<script setup>
+import { ref, computed } from 'vue'
+import { extendShare } from '../api'
+import { useToast } from 'vue-toastification'
+import { CalendarPlus, X } from 'lucide-vue-next'
+
+const props = defineProps({
+  share: {
+    type: Object,
+    required: true
+  },
+  isAdmin: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const emit = defineEmits(['close', 'extended'])
+
+const toast = useToast()
+
+// Modes: 'relative' | 'date' | 'unlimited'
+const mode = ref('relative')
+
+const amount = ref(7)
+const unit = ref('days')
+const specificDate = ref('')
+
+const submitting = ref(false)
+
+const currentExpiry = computed(() => {
+  if (!props.share.expires_at) return 'No expiration'
+  return new Date(props.share.expires_at).toLocaleDateString()
+})
+
+const minDate = computed(() => {
+  const tomorrow = new Date()
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  return tomorrow.toISOString().split('T')[0]
+})
+
+const handleSubmit = async () => {
+  submitting.value = true
+  try {
+    let payload = {}
+
+    if (mode.value === 'unlimited') {
+      payload = { unlimited: true }
+    } else if (mode.value === 'date') {
+      if (!specificDate.value) {
+        toast.error('Please select a date')
+        submitting.value = false
+        return
+      }
+      payload = { expires_at: specificDate.value }
+    } else {
+      const amt = parseInt(amount.value)
+      if (isNaN(amt) || amt < 1) {
+        toast.error('Please enter a valid amount')
+        submitting.value = false
+        return
+      }
+      payload = { amount: amt, unit: unit.value }
+    }
+
+    await extendShare(props.share.id, payload)
+    toast.success('Share expiration updated')
+    emit('extended')
+    emit('close')
+  } catch (err) {
+    toast.error(err.message || 'Failed to update expiration')
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="modal-backdrop" @click.self="emit('close')">
+    <div class="modal-box">
+      <div class="modal-header">
+        <CalendarPlus />
+        <h3>Extend Share</h3>
+        <button class="close-btn" @click="emit('close')"><X /></button>
+      </div>
+
+      <div class="current-expiry">
+        <span>Current expiry:</span>
+        <strong>{{ currentExpiry }}</strong>
+      </div>
+
+      <div v-if="isAdmin" class="mode-tabs">
+        <button :class="{ active: mode === 'relative' }" @click="mode = 'relative'">Extend by</button>
+        <button :class="{ active: mode === 'date' }" @click="mode = 'date'">Set date</button>
+        <button :class="{ active: mode === 'unlimited' }" @click="mode = 'unlimited'">No expiration</button>
+      </div>
+
+      <div class="modal-body">
+        <!-- Relative extension (all users) -->
+        <div v-if="mode === 'relative'" class="relative-picker">
+          <input
+            type="number"
+            v-model="amount"
+            min="1"
+            max="3650"
+            class="amount-input"
+          />
+          <select v-model="unit" class="unit-select">
+            <option value="days">Days</option>
+            <option value="weeks">Weeks</option>
+            <option value="months">Months</option>
+          </select>
+        </div>
+
+        <!-- Admin: specific date -->
+        <div v-else-if="mode === 'date'" class="date-picker">
+          <input
+            type="date"
+            v-model="specificDate"
+            :min="minDate"
+            class="date-input"
+          />
+        </div>
+
+        <!-- Admin: no expiration -->
+        <div v-else-if="mode === 'unlimited'" class="unlimited-info">
+          <p>This share will never expire and will not be automatically cleaned up.</p>
+        </div>
+      </div>
+
+      <div class="modal-footer">
+        <button class="secondary" @click="emit('close')" :disabled="submitting">Cancel</button>
+        <button @click="handleSubmit" :disabled="submitting">
+          {{ submitting ? 'Saving...' : 'Save' }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-box {
+  background: var(--panel-section-background-color);
+  border-radius: 10px;
+  padding: 24px;
+  min-width: 340px;
+  max-width: 480px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+
+  svg {
+    width: 1.3rem;
+    height: 1.3rem;
+    color: var(--panel-section-text-color);
+  }
+
+  h3 {
+    flex: 1;
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--panel-section-text-color);
+  }
+
+  .close-btn {
+    background: none;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    color: var(--panel-section-text-color);
+    opacity: 0.6;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    svg {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+}
+
+.current-expiry {
+  background: var(--panel-section-background-color-alt);
+  border-radius: 6px;
+  padding: 8px 12px;
+  margin-bottom: 16px;
+  font-size: 0.85rem;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  color: var(--panel-section-text-color);
+
+  strong {
+    font-weight: 600;
+  }
+}
+
+.mode-tabs {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 16px;
+
+  button {
+    flex: 1;
+    padding: 6px 10px;
+    font-size: 0.8rem;
+    border-radius: 6px;
+    background: var(--panel-section-background-color-alt);
+    border: 2px solid transparent;
+    color: var(--panel-section-text-color);
+    cursor: pointer;
+    transition: border-color 0.15s;
+
+    &.active {
+      border-color: var(--primary-color, #4f6ef7);
+    }
+
+    &:hover:not(.active) {
+      opacity: 0.8;
+    }
+  }
+}
+
+.modal-body {
+  margin-bottom: 20px;
+}
+
+.relative-picker {
+  display: flex;
+  gap: 10px;
+
+  .amount-input {
+    flex: 1;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--panel-section-background-color-alt);
+    background: var(--panel-section-background-color-alt);
+    color: var(--panel-section-text-color);
+    font-size: 1rem;
+  }
+
+  .unit-select {
+    flex: 1.5;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--panel-section-background-color-alt);
+    background: var(--panel-section-background-color-alt);
+    color: var(--panel-section-text-color);
+    font-size: 1rem;
+  }
+}
+
+.date-picker {
+  .date-input {
+    width: 100%;
+    padding: 8px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--panel-section-background-color-alt);
+    background: var(--panel-section-background-color-alt);
+    color: var(--panel-section-text-color);
+    font-size: 1rem;
+    box-sizing: border-box;
+  }
+}
+
+.unlimited-info {
+  background: var(--panel-section-background-color-alt);
+  border-radius: 6px;
+  padding: 12px;
+  font-size: 0.85rem;
+  color: var(--panel-section-text-color);
+
+  p {
+    margin: 0;
+  }
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+</style>

--- a/resources/js/components/settings/allShares.vue
+++ b/resources/js/components/settings/allShares.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, inject, defineExpose, computed } from 'vue'
-import { getAllShares, expireShare, extendShare, setDownloadLimit } from '../../api'
+import { getAllShares, expireShare, setDownloadLimit } from '../../api'
 import {
   SquareArrowOutUpRight,
   CalendarPlus,
@@ -14,6 +14,7 @@ import {
 import { useToast } from 'vue-toastification'
 import { niceFileSize, niceDate, niceFileName, niceNumber } from '../../utils'
 import HelpTip from '../helpTip.vue'
+import ExtendShareModal from '../ExtendShareModal.vue'
 import { useTranslate } from '@tolgee/vue'
 
 const { t } = useTranslate()
@@ -28,6 +29,7 @@ const loadedShares = ref(false)
 const shares = ref([])
 const showDeletedShares = ref(false)
 const selectedUserId = ref(null)
+const extendModalShare = ref(null)
 
 onMounted(async () => {
   showDeletedShares.value = localStorage.getItem('allSharesShowDeleted') === 'true'
@@ -50,15 +52,8 @@ const handleExpireShareClick = async (share) => {
     })
 }
 
-const handleExtendShareClick = async (share) => {
-  extendShare(share.id)
-    .then(() => {
-      toast.success(t.value('settings.success.shareExtended'))
-      loadShares()
-    })
-    .catch((error) => {
-      toast.error(t.value('settings.error.shareExtended'))
-    })
+const handleExtendShareClick = (share) => {
+  extendModalShare.value = share
 }
 
 const handleDownloadLimitChange = async (share) => {
@@ -118,6 +113,13 @@ defineExpose({
 
 <template>
   <div>
+    <ExtendShareModal
+      v-if="extendModalShare"
+      :share="extendModalShare"
+      :is-admin="true"
+      @close="extendModalShare = null"
+      @extended="loadShares"
+    />
     <HelpTip id="download-limit-help-tip-all" :header="$t('settings.help.downloadLimit.title')">
       <p>
         {{ $t('settings.help.downloadLimit.description') }}

--- a/resources/js/components/settings/allShares.vue
+++ b/resources/js/components/settings/allShares.vue
@@ -32,6 +32,14 @@ const shares = ref([])
 const showDeletedShares = ref(false)
 const selectedUserId = ref(null)
 
+const activeShares = computed(() =>
+  shares.value.filter(s => s.status !== 'pending_deletion')
+)
+
+const pendingDeletionShares = computed(() =>
+  shares.value.filter(s => s.status === 'pending_deletion')
+)
+
 onMounted(async () => {
   showDeletedShares.value = localStorage.getItem('allSharesShowDeleted') === 'true'
   loadShares()
@@ -87,14 +95,6 @@ const handleDownloadLimitChange = async (share) => {
 
 const downloadShare = async (share) => {
   window.location.href = `/api/shares/${share.long_id}/download`
-}
-
-const enableExpireShareButton = (share) => {
-  return !share.expired && !share.deleted
-}
-
-const enableExtendShareButton = (share) => {
-  return !share.deleted
 }
 
 const enableDownloadButton = (share) => {
@@ -162,7 +162,7 @@ defineExpose({
       </p>
     </HelpTip>
 
-    <table v-if="shares.length > 0">
+    <table v-if="activeShares.length > 0">
       <thead>
         <tr>
           <th>{{ $t('settings.table.name') }}</th>
@@ -177,7 +177,7 @@ defineExpose({
         </tr>
       </thead>
       <tbody>
-        <tr v-for="share in shares" :key="share.id">
+        <tr v-for="share in activeShares" :key="share.id">
           <td width="1" style="white-space: nowrap">
             <div class="slide-text">
               <strong class="content">{{ share.name }}</strong>
@@ -195,11 +195,6 @@ defineExpose({
                 <LockOpen />
                 {{ $t('share.passwordNotProtected') }}
               </template>
-            </div>
-            <div v-if="share.pending_deletion" class="pending-deletion-badge">
-              <Clock />
-              {{ $t('share.status.pendingDeletion') }}
-              <span class="deletion-requester">({{ share.deletion_requested_by }})</span>
             </div>
           </td>
           <td width="1" style="white-space: nowrap">
@@ -304,25 +299,72 @@ defineExpose({
                 {{ $t('share.button.requestDeletion') }}
               </button>
             </template>
-            <template v-if="share.pending_deletion">
-              <button
-                @click="handleUndoDeletionClick(share)"
-                class="secondary"
-              >
-                <Undo2 />
-                {{ $t('share.button.undoDeletion') }}
-              </button>
-            </template>
           </td>
         </tr>
       </tbody>
     </table>
-    <div v-else-if="loadedShares" class="center-message">
+    <div v-else-if="loadedShares && pendingDeletionShares.length === 0" class="center-message">
       <Rocket />
       <p>{{ $t('settings.allShares.noShares') }}</p>
     </div>
-    <div v-else class="center-message">
+    <div v-else-if="!loadedShares" class="center-message">
       <p>{{ $t('settings.loading') }}</p>
+    </div>
+
+    <!-- Pending Deletion Section -->
+    <div v-if="pendingDeletionShares.length > 0" class="pending-deletion-section">
+      <h4 class="pending-deletion-header">
+        <Clock />
+        {{ $t('settings.pendingDeletion.title') }}
+      </h4>
+      <p class="pending-deletion-description">{{ $t('settings.pendingDeletion.description') }}</p>
+      <table>
+        <thead>
+          <tr>
+            <th>{{ $t('settings.table.name') }}</th>
+            <th>{{ $t('settings.allShares.owner') }}</th>
+            <th>{{ $t('settings.table.files') }}</th>
+            <th>{{ $t('settings.pendingDeletion.requestedOn') }}</th>
+            <th>{{ $t('settings.table.actions') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="share in pendingDeletionShares" :key="share.id" class="pending-deletion-row">
+            <td width="1" style="white-space: nowrap">
+              <div class="slide-text">
+                <strong class="content">{{ share.name }}</strong>
+              </div>
+              <span class="pending-deletion-badge">
+                <Clock />
+                {{ $t('share.status.pendingDeletion') }}
+                <span class="deletion-requester">({{ share.deletion_requested_by }})</span>
+              </span>
+            </td>
+            <td width="1" style="white-space: nowrap">
+              <div class="owner-info">
+                <strong>{{ share.user_name }}</strong>
+                <small>{{ share.user_email }}</small>
+              </div>
+            </td>
+            <td style="vertical-align: top">
+              <h6 class="file-count">
+                {{ $t('share.files.count', { count: share.files.length, value: share.files.length }) }}
+              </h6>
+            </td>
+            <td width="1" style="white-space: nowrap">
+              <div class="date">{{ niceDate(share.deletion_requested_at) }}</div>
+            </td>
+            <td width="1" style="white-space: nowrap">
+              <div class="actions-cell">
+                <button @click="handleUndoDeletionClick(share)" class="secondary">
+                  <Undo2 />
+                  {{ $t('share.button.undoDeletion') }}
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>
@@ -552,6 +594,39 @@ td {
     height: 1rem;
     margin-top: -2px;
   }
+}
+
+.pending-deletion-section {
+  margin-top: 2rem;
+  border-top: 2px solid var(--panel-section-background-color-alt);
+  padding-top: 1rem;
+}
+
+.pending-deletion-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--panel-section-text-color);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+
+  svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    opacity: 0.7;
+  }
+}
+
+.pending-deletion-description {
+  font-size: 0.8rem;
+  color: var(--panel-section-text-color);
+  opacity: 0.7;
+  margin-bottom: 0.75rem;
+}
+
+.pending-deletion-row {
+  opacity: 0.8;
 }
 
 .pending-deletion-badge {

--- a/resources/js/components/settings/allShares.vue
+++ b/resources/js/components/settings/allShares.vue
@@ -33,6 +33,14 @@ const shares = ref([])
 const showDeletedShares = ref(false)
 const selectedUserId = ref(null)
 
+const activeShares = computed(() =>
+  shares.value.filter(s => s.status !== 'pending_deletion')
+)
+
+const pendingDeletionShares = computed(() =>
+  shares.value.filter(s => s.status === 'pending_deletion')
+)
+
 onMounted(async () => {
   showDeletedShares.value = localStorage.getItem('allSharesShowDeleted') === 'true'
   loadShares()
@@ -90,14 +98,6 @@ const downloadShare = async (share) => {
   window.location.href = `/api/shares/${share.long_id}/download`
 }
 
-const enableExpireShareButton = (share) => {
-  return !share.expired && !share.deleted
-}
-
-const enableExtendShareButton = (share) => {
-  return !share.deleted
-}
-
 const enableDownloadButton = (share) => {
   return !share.expired && !share.deleted && !share.pending_deletion
 }
@@ -136,9 +136,13 @@ const handleUndoDeletionClick = async (share) => {
 
 const handleDeleteImmediatelyClick = async (share) => {
   const confirmation = prompt(
-    `Type "delete" to immediately remove all files for share "${share.name}".\n\nThis cannot be undone.`
+    `Type DELETE (uppercase) to immediately remove all files for share "${share.name}".\n\nThis cannot be undone.`
   )
   if (confirmation === null) return  // user cancelled
+  if (confirmation !== 'DELETE') {
+    toast.error('Confirmation did not match — type DELETE in uppercase to confirm')
+    return
+  }
   deleteShareImmediately(share.id, confirmation)
     .then(() => {
       toast.success('Share deleted immediately')
@@ -182,7 +186,7 @@ defineExpose({
       </p>
     </HelpTip>
 
-    <table v-if="shares.length > 0">
+    <table v-if="activeShares.length > 0">
       <thead>
         <tr>
           <th>{{ $t('settings.table.name') }}</th>
@@ -197,7 +201,7 @@ defineExpose({
         </tr>
       </thead>
       <tbody>
-        <tr v-for="share in shares" :key="share.id">
+        <tr v-for="share in activeShares" :key="share.id">
           <td width="1" style="white-space: nowrap">
             <div class="slide-text">
               <strong class="content">{{ share.name }}</strong>
@@ -215,11 +219,6 @@ defineExpose({
                 <LockOpen />
                 {{ $t('share.passwordNotProtected') }}
               </template>
-            </div>
-            <div v-if="share.pending_deletion" class="pending-deletion-badge">
-              <Clock />
-              {{ $t('share.status.pendingDeletion') }}
-              <span class="deletion-requester">({{ share.deletion_requested_by }})</span>
             </div>
           </td>
           <td width="1" style="white-space: nowrap">
@@ -324,35 +323,76 @@ defineExpose({
                 {{ $t('share.button.requestDeletion') }}
               </button>
             </template>
-            <template v-if="share.pending_deletion">
-              <button
-                @click="handleUndoDeletionClick(share)"
-                class="secondary"
-              >
-                <Undo2 />
-                {{ $t('share.button.undoDeletion') }}
-              </button>
-            </template>
-            <template v-if="canDeleteImmediately(share)">
-              <button
-                @click="handleDeleteImmediatelyClick(share)"
-                class="danger"
-                :title="$t('share.button.deleteImmediately')"
-              >
-                <OctagonX />
-                {{ $t('share.button.deleteImmediately') }}
-              </button>
-            </template>
           </td>
         </tr>
       </tbody>
     </table>
-    <div v-else-if="loadedShares" class="center-message">
+    <div v-else-if="loadedShares && pendingDeletionShares.length === 0" class="center-message">
       <Rocket />
       <p>{{ $t('settings.allShares.noShares') }}</p>
     </div>
-    <div v-else class="center-message">
+    <div v-else-if="!loadedShares" class="center-message">
       <p>{{ $t('settings.loading') }}</p>
+    </div>
+
+    <!-- Pending Deletion Section -->
+    <div v-if="pendingDeletionShares.length > 0" class="pending-deletion-section">
+      <h4 class="pending-deletion-header">
+        <Clock />
+        {{ $t('settings.pendingDeletion.title') }}
+      </h4>
+      <p class="pending-deletion-description">{{ $t('settings.pendingDeletion.description') }}</p>
+      <table>
+        <thead>
+          <tr>
+            <th>{{ $t('settings.table.name') }}</th>
+            <th>{{ $t('settings.allShares.owner') }}</th>
+            <th>{{ $t('settings.table.files') }}</th>
+            <th>{{ $t('settings.pendingDeletion.requestedOn') }}</th>
+            <th>{{ $t('settings.table.actions') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="share in pendingDeletionShares" :key="share.id" class="pending-deletion-row">
+            <td width="1" style="white-space: nowrap">
+              <div class="slide-text">
+                <strong class="content">{{ share.name }}</strong>
+              </div>
+              <span class="pending-deletion-badge">
+                <Clock />
+                {{ $t('share.status.pendingDeletion') }}
+                <span class="deletion-requester">({{ share.deletion_requested_by }})</span>
+              </span>
+            </td>
+            <td width="1" style="white-space: nowrap">
+              <div class="owner-info">
+                <strong>{{ share.user_name }}</strong>
+                <small>{{ share.user_email }}</small>
+              </div>
+            </td>
+            <td style="vertical-align: top">
+              <h6 class="file-count">
+                {{ $t('share.files.count', { count: share.files.length, value: share.files.length }) }}
+              </h6>
+            </td>
+            <td width="1" style="white-space: nowrap">
+              <div class="date">{{ niceDate(share.deletion_requested_at) }}</div>
+            </td>
+            <td width="1" style="white-space: nowrap">
+              <div class="actions-cell">
+                <button @click="handleUndoDeletionClick(share)" class="secondary">
+                  <Undo2 />
+                  {{ $t('share.button.undoDeletion') }}
+                </button>
+                <button @click="handleDeleteImmediatelyClick(share)" class="danger">
+                  <OctagonX />
+                  {{ $t('share.button.deleteImmediately') }}
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>
@@ -582,6 +622,39 @@ td {
     height: 1rem;
     margin-top: -2px;
   }
+}
+
+.pending-deletion-section {
+  margin-top: 2rem;
+  border-top: 2px solid var(--panel-section-background-color-alt);
+  padding-top: 1rem;
+}
+
+.pending-deletion-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--panel-section-text-color);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+
+  svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    opacity: 0.7;
+  }
+}
+
+.pending-deletion-description {
+  font-size: 0.8rem;
+  color: var(--panel-section-text-color);
+  opacity: 0.7;
+  margin-bottom: 0.75rem;
+}
+
+.pending-deletion-row {
+  opacity: 0.8;
 }
 
 .pending-deletion-badge {

--- a/resources/js/components/settings/allShares.vue
+++ b/resources/js/components/settings/allShares.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, inject, defineExpose, computed } from 'vue'
-import { getAllShares, expireShare, extendShare, setDownloadLimit } from '../../api'
+import { getAllShares, expireShare, extendShare, setDownloadLimit, requestShareDeletion, undoShareDeletion } from '../../api'
 import {
   SquareArrowOutUpRight,
   CalendarPlus,
@@ -9,7 +9,10 @@ import {
   MessageCircleQuestion,
   Rocket,
   Lock,
-  LockOpen
+  LockOpen,
+  Clock,
+  Trash2,
+  Undo2
 } from 'lucide-vue-next'
 import { useToast } from 'vue-toastification'
 import { niceFileSize, niceDate, niceFileName, niceNumber } from '../../utils'
@@ -95,7 +98,39 @@ const enableExtendShareButton = (share) => {
 }
 
 const enableDownloadButton = (share) => {
-  return !share.expired && !share.deleted
+  return !share.expired && !share.deleted && !share.pending_deletion
+}
+
+const enableExpireShareButton = (share) => {
+  return !share.expired && !share.deleted && !share.pending_deletion
+}
+
+const enableExtendShareButton = (share) => {
+  return !share.deleted && !share.pending_deletion
+}
+
+const handleRequestDeletionClick = async (share) => {
+  const confirmed = confirm(`Place share "${share.name}" into pending deletion? The link will stop working immediately.`)
+  if (!confirmed) return
+  requestShareDeletion(share.id)
+    .then(() => {
+      toast.success('Share marked for deletion')
+      loadShares()
+    })
+    .catch((error) => {
+      toast.error('Failed to mark share for deletion')
+    })
+}
+
+const handleUndoDeletionClick = async (share) => {
+  undoShareDeletion(share.id)
+    .then(() => {
+      toast.success('Share deletion undone')
+      loadShares()
+    })
+    .catch((error) => {
+      toast.error('Failed to undo share deletion')
+    })
 }
 
 const setShowDeletedShares = (value) => {
@@ -160,6 +195,11 @@ defineExpose({
                 <LockOpen />
                 {{ $t('share.passwordNotProtected') }}
               </template>
+            </div>
+            <div v-if="share.pending_deletion" class="pending-deletion-badge">
+              <Clock />
+              {{ $t('share.status.pendingDeletion') }}
+              <span class="deletion-requester">({{ share.deletion_requested_by }})</span>
             </div>
           </td>
           <td width="1" style="white-space: nowrap">
@@ -254,6 +294,25 @@ defineExpose({
             >
               <HardDriveDownload style="margin-right: 0" />
             </button>
+            <template v-if="!share.pending_deletion && !share.deleted">
+              <button
+                @click="handleRequestDeletionClick(share)"
+                class="danger"
+                :title="$t('share.button.requestDeletion')"
+              >
+                <Trash2 />
+                {{ $t('share.button.requestDeletion') }}
+              </button>
+            </template>
+            <template v-if="share.pending_deletion">
+              <button
+                @click="handleUndoDeletionClick(share)"
+                class="secondary"
+              >
+                <Undo2 />
+                {{ $t('share.button.undoDeletion') }}
+              </button>
+            </template>
           </td>
         </tr>
       </tbody>
@@ -492,6 +551,29 @@ td {
     width: 1rem;
     height: 1rem;
     margin-top: -2px;
+  }
+}
+
+.pending-deletion-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.65rem;
+  color: var(--panel-section-text-color);
+  background: var(--panel-section-background-color-alt);
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-top: 4px;
+  opacity: 0.8;
+
+  svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
+
+  .deletion-requester {
+    opacity: 0.6;
+    font-style: italic;
   }
 }
 </style>

--- a/resources/js/components/settings/allShares.vue
+++ b/resources/js/components/settings/allShares.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, inject, defineExpose, computed } from 'vue'
-import { getAllShares, expireShare, extendShare, setDownloadLimit, requestShareDeletion, undoShareDeletion } from '../../api'
+import { getAllShares, expireShare, extendShare, setDownloadLimit, requestShareDeletion, undoShareDeletion, deleteShareImmediately } from '../../api'
 import {
   SquareArrowOutUpRight,
   CalendarPlus,
@@ -12,7 +12,8 @@ import {
   LockOpen,
   Clock,
   Trash2,
-  Undo2
+  Undo2,
+  OctagonX
 } from 'lucide-vue-next'
 import { useToast } from 'vue-toastification'
 import { niceFileSize, niceDate, niceFileName, niceNumber } from '../../utils'
@@ -131,6 +132,25 @@ const handleUndoDeletionClick = async (share) => {
     .catch((error) => {
       toast.error('Failed to undo share deletion')
     })
+}
+
+const handleDeleteImmediatelyClick = async (share) => {
+  const confirmation = prompt(
+    `Type "delete" to immediately remove all files for share "${share.name}".\n\nThis cannot be undone.`
+  )
+  if (confirmation === null) return  // user cancelled
+  deleteShareImmediately(share.id, confirmation)
+    .then(() => {
+      toast.success('Share deleted immediately')
+      loadShares()
+    })
+    .catch((error) => {
+      toast.error(error.message || 'Failed to delete share')
+    })
+}
+
+const canDeleteImmediately = (share) => {
+  return share.pending_deletion || (share.expired && !share.deleted)
 }
 
 const setShowDeletedShares = (value) => {
@@ -311,6 +331,16 @@ defineExpose({
               >
                 <Undo2 />
                 {{ $t('share.button.undoDeletion') }}
+              </button>
+            </template>
+            <template v-if="canDeleteImmediately(share)">
+              <button
+                @click="handleDeleteImmediatelyClick(share)"
+                class="danger"
+                :title="$t('share.button.deleteImmediately')"
+              >
+                <OctagonX />
+                {{ $t('share.button.deleteImmediately') }}
               </button>
             </template>
           </td>

--- a/resources/js/components/settings/allShares.vue
+++ b/resources/js/components/settings/allShares.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { ref, onMounted, inject, defineExpose, computed } from 'vue'
-import { getAllShares, expireShare, extendShare, setDownloadLimit, requestShareDeletion, undoShareDeletion, deleteShareImmediately } from '../../api'
+import { ref, onMounted, onUnmounted, inject, defineExpose, computed } from 'vue'
+import { getAllShares, expireShare, extendShare, setDownloadLimit, requestShareDeletion, undoShareDeletion, deleteShareImmediately, purgeShare } from '../../api'
 import {
   SquareArrowOutUpRight,
   CalendarPlus,
@@ -13,7 +13,8 @@ import {
   Clock,
   Trash2,
   Undo2,
-  OctagonX
+  OctagonX,
+  ChevronDown
 } from 'lucide-vue-next'
 import { useToast } from 'vue-toastification'
 import { niceFileSize, niceDate, niceFileName, niceNumber } from '../../utils'
@@ -34,6 +35,7 @@ const shares = ref([])
 const showDeletedShares = ref(false)
 const selectedUserId = ref(null)
 const extendModalShare = ref(null)
+const openDropdownId = ref(null)
 
 const activeShares = computed(() =>
   shares.value.filter(s => s.status !== 'pending_deletion')
@@ -43,9 +45,22 @@ const pendingDeletionShares = computed(() =>
   shares.value.filter(s => s.status === 'pending_deletion')
 )
 
+const toggleDropdown = (id) => {
+  openDropdownId.value = openDropdownId.value === id ? null : id
+}
+
+const closeDropdown = () => {
+  openDropdownId.value = null
+}
+
 onMounted(async () => {
   showDeletedShares.value = localStorage.getItem('allSharesShowDeleted') === 'true'
   loadShares()
+  document.addEventListener('click', closeDropdown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', closeDropdown)
 })
 
 const loadShares = async () => {
@@ -150,6 +165,23 @@ const handleDeleteImmediatelyClick = async (share) => {
 
 const canDeleteImmediately = (share) => {
   return share.pending_deletion || (share.expired && !share.deleted)
+}
+
+const handlePurgeShareClick = async (share) => {
+  const input = prompt(t.value('settings.pendingDeletion.confirmPrompt'))
+  if (input === null) return
+  if (input !== 'DELETE') {
+    toast.error(t.value('settings.pendingDeletion.confirmMismatch'))
+    return
+  }
+  purgeShare(share.id)
+    .then(() => {
+      toast.success('Share record removed')
+      loadShares()
+    })
+    .catch((e) => {
+      toast.error(e.message || 'Failed to remove share record')
+    })
 }
 
 const setShowDeletedShares = (value) => {
@@ -291,40 +323,68 @@ defineExpose({
             </div>
           </td>
           <td width="1" style="white-space: nowrap">
-            <button
-              @click="handleExpireShareClick(share)"
-              class="clear-button"
-              :disabled="!enableExpireShareButton(share)"
-            >
-              <CalendarX2 />
-              {{ $t('share.button.expireNow') }}
-            </button>
-            <button
-              @click="handleExtendShareClick(share)"
-              class="secondary"
-              :disabled="!enableExtendShareButton(share)"
-            >
-              <CalendarPlus />
-              {{ $t('share.button.extend') }}
-            </button>
-            <button
-              @click="downloadShare(share)"
-              class="secondary icon-only"
-              title="Download all files"
-              :disabled="!enableDownloadButton(share)"
-            >
-              <HardDriveDownload style="margin-right: 0" />
-            </button>
-            <template v-if="!share.pending_deletion && !share.deleted">
+            <div class="actions-cell">
+              <div class="split-btn-group" :class="{ open: openDropdownId === share.id }" @click.stop>
+                <button
+                  class="split-btn-main clear-button"
+                  @click="handleExpireShareClick(share)"
+                  :disabled="!enableExpireShareButton(share)"
+                  :title="$t('share.button.expireNow')"
+                >
+                  <CalendarX2 />
+                  {{ $t('share.button.expireNow') }}
+                </button>
+                <button
+                  class="split-btn-chevron clear-button"
+                  @click="toggleDropdown(share.id)"
+                  title="More actions"
+                >
+                  <ChevronDown />
+                </button>
+                <div v-if="openDropdownId === share.id" class="action-dropdown">
+                  <button
+                    v-if="enableExtendShareButton(share)"
+                    class="dropdown-item"
+                    @click="handleExtendShareClick(share); closeDropdown()"
+                  >
+                    <CalendarPlus />
+                    {{ $t('share.button.extend') }}
+                  </button>
+                  <button
+                    v-if="!share.pending_deletion && !share.deleted"
+                    class="dropdown-item danger"
+                    @click="handleRequestDeletionClick(share); closeDropdown()"
+                  >
+                    <Trash2 />
+                    {{ $t('share.button.requestDeletion') }}
+                  </button>
+                  <button
+                    v-if="canDeleteImmediately(share)"
+                    class="dropdown-item danger"
+                    @click="handleDeleteImmediatelyClick(share); closeDropdown()"
+                  >
+                    <OctagonX />
+                    {{ $t('share.button.deleteImmediately') }}
+                  </button>
+                  <button
+                    v-if="share.deleted"
+                    class="dropdown-item danger"
+                    @click="handlePurgeShareClick(share); closeDropdown()"
+                  >
+                    <Trash2 />
+                    {{ $t('share.button.removeEntry') }}
+                  </button>
+                </div>
+              </div>
               <button
-                @click="handleRequestDeletionClick(share)"
-                class="danger"
-                :title="$t('share.button.requestDeletion')"
+                class="secondary icon-only"
+                @click="downloadShare(share)"
+                :disabled="!enableDownloadButton(share)"
+                title="Download all files"
               >
-                <Trash2 />
-                {{ $t('share.button.requestDeletion') }}
+                <HardDriveDownload style="margin-right: 0" />
               </button>
-            </template>
+            </div>
           </td>
         </tr>
       </tbody>
@@ -679,6 +739,94 @@ td {
   .deletion-requester {
     opacity: 0.6;
     font-style: italic;
+  }
+}
+
+.actions-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  // Suppress global button margin-right so gap alone controls spacing
+  button {
+    margin-right: 0 !important;
+  }
+}
+
+.split-btn-group {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+
+  .split-btn-main {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+    border-right: 1px solid rgba(128, 128, 128, 0.25) !important;
+    margin-right: 0 !important;
+  }
+
+  .split-btn-chevron {
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+    padding: 0 7px !important;
+    min-width: unset !important;
+    margin-right: 0 !important;
+
+    svg {
+      width: 0.8rem;
+      height: 0.8rem;
+      margin: 0 !important;
+      transition: transform 0.15s;
+    }
+  }
+
+  &.open .split-btn-chevron svg {
+    transform: rotate(180deg);
+  }
+
+  .action-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 200;
+    background: var(--panel-section-background-color);
+    border: 1px solid rgba(128, 128, 128, 0.2);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    min-width: 190px;
+    overflow: hidden;
+
+    .dropdown-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      padding: 9px 14px;
+      background: none;
+      border: none;
+      border-radius: 0;
+      text-align: left;
+      font-size: 0.85rem;
+      color: var(--panel-section-text-color);
+      cursor: pointer;
+      white-space: nowrap;
+      margin: 0;
+
+      &:hover {
+        background: var(--panel-section-background-color-alt);
+      }
+
+      &.danger {
+        color: #dc3545;
+        svg { color: #dc3545; }
+      }
+
+      svg {
+        width: 0.9rem;
+        height: 0.9rem;
+        flex-shrink: 0;
+      }
+    }
   }
 }
 </style>

--- a/resources/js/components/settings/allShares.vue
+++ b/resources/js/components/settings/allShares.vue
@@ -502,11 +502,6 @@ defineExpose({
   .some-more {
     font-size: 0.7rem;
     color: var(--panel-section-text-color);
-    margin-left: 10px;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 }
 

--- a/resources/js/components/settings/myShares.vue
+++ b/resources/js/components/settings/myShares.vue
@@ -137,8 +137,10 @@ const handleUndoDeletionClick = async (share) => {
 }
 
 const handlePruneExpiredShares = async () => {
-  const confirmed = confirm(t.value('settings.confirm.pruneExpiredShares'))
-  if (!confirmed) {
+  const input = prompt(t.value('settings.pendingDeletion.confirmPrompt'))
+  if (input === null) return // cancelled
+  if (input !== 'DELETE') {
+    toast.error(t.value('settings.pendingDeletion.confirmMismatch'))
     return
   }
   try {
@@ -317,11 +319,19 @@ defineExpose({
 
     <!-- Pending Deletion Section -->
     <div v-if="pendingDeletionShares.length > 0" class="pending-deletion-section">
-      <h4 class="pending-deletion-header">
-        <Clock />
-        {{ $t('settings.pendingDeletion.title') }}
-      </h4>
-      <p class="pending-deletion-description">{{ $t('settings.pendingDeletion.description') }}</p>
+      <div class="pending-deletion-section-header">
+        <div>
+          <h4 class="pending-deletion-header">
+            <Clock />
+            {{ $t('settings.pendingDeletion.title') }}
+          </h4>
+          <p class="pending-deletion-description">{{ $t('settings.pendingDeletion.description') }}</p>
+        </div>
+        <button class="danger" @click="handlePruneExpiredShares">
+          <Trash2 />
+          {{ $t('settings.pendingDeletion.deleteAll') }}
+        </button>
+      </div>
       <table>
         <thead>
           <tr>
@@ -586,6 +596,19 @@ td {
   margin-right: 5px;
   vertical-align: middle;
   opacity: 0.7;
+}
+
+.pending-deletion-section-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 0.75rem;
+
+  button {
+    flex-shrink: 0;
+    margin-top: 4px;
+  }
 }
 
 .pending-deletion-section {

--- a/resources/js/components/settings/myShares.vue
+++ b/resources/js/components/settings/myShares.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, inject, defineExpose } from 'vue'
-import { getMyShares, expireShare, extendShare, setDownloadLimit, pruneExpiredShares } from '../../api'
+import { getMyShares, expireShare, setDownloadLimit, pruneExpiredShares } from '../../api'
 import {
   SquareArrowOutUpRight,
   CalendarPlus,
@@ -15,6 +15,7 @@ import {
 import { useToast } from 'vue-toastification'
 import { niceFileSize, niceDate, niceFileName, niceNumber } from '../../utils'
 import HelpTip from '../helpTip.vue'
+import ExtendShareModal from '../ExtendShareModal.vue'
 import { useTranslate } from '@tolgee/vue'
 
 const { t } = useTranslate()
@@ -28,6 +29,8 @@ const loadedShares = ref(false)
 
 const shares = ref([])
 const showDeletedShares = ref(false)
+const extendModalShare = ref(null)
+
 onMounted(async () => {
   showDeletedShares.value = localStorage.getItem('showDeletedShares') === 'true'
   loadShares()
@@ -49,15 +52,8 @@ const handleExpireShareClick = async (share) => {
     })
 }
 
-const handleExtendShareClick = async (share) => {
-  extendShare(share.id)
-    .then(() => {
-      toast.success(t.value('settings.success.shareExtended'))
-      loadShares()
-    })
-    .catch((error) => {
-      toast.error(t.value('settings.error.shareExtended'))
-    })
+const handleExtendShareClick = (share) => {
+  extendModalShare.value = share
 }
 
 const handleDownloadLimitChange = async (share) => {
@@ -124,6 +120,13 @@ defineExpose({
 
 <template>
   <div>
+    <ExtendShareModal
+      v-if="extendModalShare"
+      :share="extendModalShare"
+      :is-admin="false"
+      @close="extendModalShare = null"
+      @extended="loadShares"
+    />
     <HelpTip id="download-limit-help-tip" :header="$t('settings.help.downloadLimit.title')">
       <p>
         {{ $t('settings.help.downloadLimit.description') }}

--- a/resources/js/components/settings/myShares.vue
+++ b/resources/js/components/settings/myShares.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { ref, computed, onMounted, inject, defineExpose } from 'vue'
-import { getMyShares, expireShare, extendShare, setDownloadLimit, pruneExpiredShares, requestShareDeletion, undoShareDeletion } from '../../api'
+import { ref, computed, onMounted, onUnmounted, inject, defineExpose } from 'vue'
+import { getMyShares, expireShare, extendShare, setDownloadLimit, pruneExpiredShares, requestShareDeletion, undoShareDeletion, purgeShare } from '../../api'
 import {
   SquareArrowOutUpRight,
   CalendarPlus,
@@ -13,7 +13,8 @@ import {
   ArrowLeftRight,
   Trash2,
   Undo2,
-  Clock
+  Clock,
+  ChevronDown
 } from 'lucide-vue-next'
 import { useToast } from 'vue-toastification'
 import { niceFileSize, niceDate, niceFileName, niceNumber } from '../../utils'
@@ -33,10 +34,24 @@ const loadedShares = ref(false)
 const shares = ref([])
 const showDeletedShares = ref(false)
 const extendModalShare = ref(null)
+const openDropdownId = ref(null)
+
+const toggleDropdown = (id) => {
+  openDropdownId.value = openDropdownId.value === id ? null : id
+}
+
+const closeDropdown = () => {
+  openDropdownId.value = null
+}
 
 onMounted(async () => {
   showDeletedShares.value = localStorage.getItem('showDeletedShares') === 'true'
   loadShares()
+  document.addEventListener('click', closeDropdown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', closeDropdown)
 })
 
 const loadShares = async () => {
@@ -133,6 +148,23 @@ const handleUndoDeletionClick = async (share) => {
     })
     .catch(() => {
       toast.error(t.value('settings.error.undoDeletion'))
+    })
+}
+
+const handlePurgeShareClick = async (share) => {
+  const input = prompt(t.value('settings.pendingDeletion.confirmPrompt'))
+  if (input === null) return
+  if (input !== 'DELETE') {
+    toast.error(t.value('settings.pendingDeletion.confirmMismatch'))
+    return
+  }
+  purgeShare(share.id)
+    .then(() => {
+      toast.success('Share record removed')
+      loadShares()
+    })
+    .catch((e) => {
+      toast.error(e.message || 'Failed to remove share record')
     })
 }
 
@@ -289,39 +321,68 @@ defineExpose({
             </div>
           </td>
           <td width="1" style="white-space: nowrap">
-            <button
-              @click="handleExpireShareClick(share)"
-              class="clear-button"
-              :disabled="!enableExpireShareButton(share)"
-            >
-              <CalendarX2 />
-              {{ $t('share.button.expireNow') }}
-            </button>
-            <button
-              @click="handleExtendShareClick(share)"
-              class="secondary"
-              :disabled="!enableExtendShareButton(share)"
-            >
-              <CalendarPlus />
-              {{ $t('share.button.extend') }}
-            </button>
-            <button
-              @click="downloadShare(share)"
-              class="secondary icon-only"
-              title="Download all files"
-              :disabled="!enableDownloadButton(share)"
-            >
-              <HardDriveDownload style="margin-right: 0" />
-            </button>
-            <button
-              @click="handleRequestDeletionClick(share)"
-              class="danger"
-              :disabled="!enableRequestDeletionButton(share)"
-              :title="$t('share.button.requestDeletion')"
-            >
-              <Trash2 />
-              {{ $t('share.button.requestDeletion') }}
-            </button>
+            <div class="actions-cell">
+              <div class="split-btn-group" :class="{ open: openDropdownId === share.id }" @click.stop>
+                <button
+                  class="split-btn-main clear-button"
+                  @click="handleExpireShareClick(share)"
+                  :disabled="!enableExpireShareButton(share)"
+                  :title="$t('share.button.expireNow')"
+                >
+                  <CalendarX2 />
+                  {{ $t('share.button.expireNow') }}
+                </button>
+                <button
+                  class="split-btn-chevron clear-button"
+                  @click="toggleDropdown(share.id)"
+                  title="More actions"
+                >
+                  <ChevronDown />
+                </button>
+                <div v-if="openDropdownId === share.id" class="action-dropdown">
+                  <button
+                    v-if="enableExtendShareButton(share)"
+                    class="dropdown-item"
+                    @click="handleExtendShareClick(share); closeDropdown()"
+                  >
+                    <CalendarPlus />
+                    {{ $t('share.button.extend') }}
+                  </button>
+                  <button
+                    v-if="enableRequestDeletionButton(share)"
+                    class="dropdown-item danger"
+                    @click="handleRequestDeletionClick(share); closeDropdown()"
+                  >
+                    <Trash2 />
+                    {{ $t('share.button.requestDeletion') }}
+                  </button>
+                  <button
+                    v-if="share.pending_deletion"
+                    class="dropdown-item"
+                    @click="handleUndoDeletionClick(share); closeDropdown()"
+                  >
+                    <Undo2 />
+                    {{ $t('share.button.undoDeletion') }}
+                  </button>
+                  <button
+                    v-if="share.deleted"
+                    class="dropdown-item danger"
+                    @click="handlePurgeShareClick(share); closeDropdown()"
+                  >
+                    <Trash2 />
+                    {{ $t('share.button.removeEntry') }}
+                  </button>
+                </div>
+              </div>
+              <button
+                class="secondary icon-only"
+                @click="downloadShare(share)"
+                :disabled="!enableDownloadButton(share)"
+                title="Download all files"
+              >
+                <HardDriveDownload style="margin-right: 0" />
+              </button>
+            </div>
           </td>
         </tr>
       </tbody>
@@ -721,6 +782,94 @@ td {
   svg {
     width: 0.75rem;
     height: 0.75rem;
+  }
+}
+
+.actions-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  // Suppress global button margin-right so gap alone controls spacing
+  button {
+    margin-right: 0 !important;
+  }
+}
+
+.split-btn-group {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+
+  .split-btn-main {
+    border-top-right-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+    border-right: 1px solid rgba(128, 128, 128, 0.25) !important;
+    margin-right: 0 !important;
+  }
+
+  .split-btn-chevron {
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+    padding: 0 7px !important;
+    min-width: unset !important;
+    margin-right: 0 !important;
+
+    svg {
+      width: 0.8rem;
+      height: 0.8rem;
+      margin: 0 !important;
+      transition: transform 0.15s;
+    }
+  }
+
+  &.open .split-btn-chevron svg {
+    transform: rotate(180deg);
+  }
+
+  .action-dropdown {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 200;
+    background: var(--panel-section-background-color);
+    border: 1px solid rgba(128, 128, 128, 0.2);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    min-width: 190px;
+    overflow: hidden;
+
+    .dropdown-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      width: 100%;
+      padding: 9px 14px;
+      background: none;
+      border: none;
+      border-radius: 0;
+      text-align: left;
+      font-size: 0.85rem;
+      color: var(--panel-section-text-color);
+      cursor: pointer;
+      white-space: nowrap;
+      margin: 0;
+
+      &:hover {
+        background: var(--panel-section-background-color-alt);
+      }
+
+      &.danger {
+        color: #dc3545;
+        svg { color: #dc3545; }
+      }
+
+      svg {
+        width: 0.9rem;
+        height: 0.9rem;
+        flex-shrink: 0;
+      }
+    }
   }
 }
 </style>

--- a/resources/js/components/settings/myShares.vue
+++ b/resources/js/components/settings/myShares.vue
@@ -49,6 +49,10 @@ const pendingDeletionShares = computed(() =>
   shares.value.filter(s => s.status === 'pending_deletion')
 )
 
+const expiredShares = computed(() =>
+  shares.value.filter(s => s.expired && !s.deleted && s.status !== 'pending_deletion')
+)
+
 const handleExpireShareClick = async (share) => {
   expireShare(share.id)
     .then(() => {
@@ -173,6 +177,16 @@ defineExpose({
         {{ $t('settings.help.downloadLimit.description2') }}
       </p>
     </HelpTip>
+    <div v-if="expiredShares.length > 0" class="expired-shares-notice">
+      <div class="expired-shares-notice-content">
+        <CalendarX2 class="expired-notice-icon" />
+        <div>
+          <strong>{{ $t('settings.expiredShares.title', { count: expiredShares.length }) }}</strong>
+          <p>{{ $t('settings.expiredShares.notice') }}</p>
+        </div>
+      </div>
+    </div>
+
     <table v-if="activeShares.length > 0">
       <thead>
         <tr>
@@ -374,6 +388,51 @@ defineExpose({
 </template>
 
 <style lang="scss" scoped>
+.expired-shares-notice {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin-bottom: 16px;
+
+  .expired-shares-notice-content {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+
+    .expired-notice-icon {
+      width: 1.2rem;
+      height: 1.2rem;
+      color: #f59e0b;
+      flex-shrink: 0;
+      margin-top: 2px;
+    }
+
+    strong {
+      display: block;
+      font-size: 0.9rem;
+      color: var(--panel-section-text-color);
+      margin-bottom: 2px;
+    }
+
+    p {
+      margin: 0;
+      font-size: 0.82rem;
+      color: var(--panel-section-text-color);
+      opacity: 0.8;
+      line-height: 1.5;
+    }
+  }
+
+  button {
+    flex-shrink: 0;
+  }
+}
+
 .files-container {
   display: flex;
   flex-direction: row;

--- a/resources/js/components/settings/myShares.vue
+++ b/resources/js/components/settings/myShares.vue
@@ -499,9 +499,10 @@ defineExpose({
 
 .files-container {
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 10px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  max-width: 220px;
   .file {
     display: flex;
     flex-direction: column;
@@ -509,10 +510,14 @@ defineExpose({
     border-radius: 5px;
     padding: 5px 10px;
     gap: 1px;
+    width: 100%;
     .file-name {
       font-size: 0.85rem;
       font-weight: bold;
       color: var(--panel-section-text-color);
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
     }
     .file-size {
       font-size: 0.7rem;
@@ -522,11 +527,6 @@ defineExpose({
   .some-more {
     font-size: 0.7rem;
     color: var(--panel-section-text-color);
-    margin-left: 10px;
-    height: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
   }
 }
 

--- a/resources/js/components/settings/myShares.vue
+++ b/resources/js/components/settings/myShares.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { ref, onMounted, inject, defineExpose } from 'vue'
-import { getMyShares, expireShare, extendShare, setDownloadLimit, pruneExpiredShares } from '../../api'
+import { ref, computed, onMounted, inject, defineExpose } from 'vue'
+import { getMyShares, expireShare, extendShare, setDownloadLimit, pruneExpiredShares, requestShareDeletion, undoShareDeletion } from '../../api'
 import {
   SquareArrowOutUpRight,
   CalendarPlus,
@@ -10,7 +10,10 @@ import {
   Rocket,
   Lock,
   LockOpen,
-  ArrowLeftRight
+  ArrowLeftRight,
+  Trash2,
+  Undo2,
+  Clock
 } from 'lucide-vue-next'
 import { useToast } from 'vue-toastification'
 import { niceFileSize, niceDate, niceFileName, niceNumber } from '../../utils'
@@ -37,6 +40,14 @@ const loadShares = async () => {
   shares.value = await getMyShares(showDeletedShares.value)
   loadedShares.value = true
 }
+
+const activeShares = computed(() =>
+  shares.value.filter(s => s.status !== 'pending_deletion')
+)
+
+const pendingDeletionShares = computed(() =>
+  shares.value.filter(s => s.status === 'pending_deletion')
+)
 
 const handleExpireShareClick = async (share) => {
   expireShare(share.id)
@@ -97,6 +108,34 @@ const enableDownloadButton = (share) => {
   return !share.expired && !share.deleted
 }
 
+const enableRequestDeletionButton = (share) => {
+  return !share.deleted && !share.pending_deletion
+}
+
+const handleRequestDeletionClick = async (share) => {
+  const confirmed = confirm(t.value('settings.confirm.requestDeletion'))
+  if (!confirmed) return
+  requestShareDeletion(share.id)
+    .then(() => {
+      toast.success(t.value('settings.success.requestDeletion'))
+      loadShares()
+    })
+    .catch(() => {
+      toast.error(t.value('settings.error.requestDeletion'))
+    })
+}
+
+const handleUndoDeletionClick = async (share) => {
+  undoShareDeletion(share.id)
+    .then(() => {
+      toast.success(t.value('settings.success.undoDeletion'))
+      loadShares()
+    })
+    .catch(() => {
+      toast.error(t.value('settings.error.undoDeletion'))
+    })
+}
+
 const handlePruneExpiredShares = async () => {
   const confirmed = confirm(t.value('settings.confirm.pruneExpiredShares'))
   if (!confirmed) {
@@ -132,7 +171,7 @@ defineExpose({
         {{ $t('settings.help.downloadLimit.description2') }}
       </p>
     </HelpTip>
-    <table v-if="shares.length > 0">
+    <table v-if="activeShares.length > 0">
       <thead>
         <tr>
           <th>{{ $t('settings.table.name') }}</th>
@@ -146,7 +185,7 @@ defineExpose({
         </tr>
       </thead>
       <tbody>
-        <tr v-for="share in shares" :key="share.id" :class="{ 'reverse-share': share.shared_with_me }">
+        <tr v-for="share in activeShares" :key="share.id" :class="{ 'reverse-share': share.shared_with_me }">
           <td width="1" style="white-space: nowrap">
             <div class="slide-text">
               <strong class="content">
@@ -255,16 +294,71 @@ defineExpose({
             >
               <HardDriveDownload style="margin-right: 0" />
             </button>
+            <button
+              @click="handleRequestDeletionClick(share)"
+              class="danger"
+              :disabled="!enableRequestDeletionButton(share)"
+              :title="$t('share.button.requestDeletion')"
+            >
+              <Trash2 />
+              {{ $t('share.button.requestDeletion') }}
+            </button>
           </td>
         </tr>
       </tbody>
     </table>
-    <div v-else-if="loadedShares" class="center-message">
+    <div v-else-if="loadedShares && pendingDeletionShares.length === 0" class="center-message">
       <Rocket />
       <p>{{ $t('settings.noShares') }}</p>
     </div>
-    <div v-else class="center-message">
+    <div v-else-if="!loadedShares" class="center-message">
       <p>{{ $t('settings.loading') }}</p>
+    </div>
+
+    <!-- Pending Deletion Section -->
+    <div v-if="pendingDeletionShares.length > 0" class="pending-deletion-section">
+      <h4 class="pending-deletion-header">
+        <Clock />
+        {{ $t('settings.pendingDeletion.title') }}
+      </h4>
+      <p class="pending-deletion-description">{{ $t('settings.pendingDeletion.description') }}</p>
+      <table>
+        <thead>
+          <tr>
+            <th>{{ $t('settings.table.name') }}</th>
+            <th>{{ $t('settings.table.files') }}</th>
+            <th>{{ $t('settings.pendingDeletion.requestedOn') }}</th>
+            <th>{{ $t('settings.table.actions') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="share in pendingDeletionShares" :key="share.id" class="pending-deletion-row">
+            <td width="1" style="white-space: nowrap">
+              <div class="slide-text">
+                <strong class="content">{{ share.name }}</strong>
+              </div>
+              <span class="pending-deletion-badge">
+                <Clock />
+                {{ $t('share.status.pendingDeletion') }}
+              </span>
+            </td>
+            <td style="vertical-align: top">
+              <h6 class="file-count">
+                {{ $t('share.files.count', { count: share.files.length, value: share.files.length }) }}
+              </h6>
+            </td>
+            <td width="1" style="white-space: nowrap">
+              <div class="date">{{ niceDate(share.deletion_requested_at) }}</div>
+            </td>
+            <td width="1" style="white-space: nowrap">
+              <button @click="handleUndoDeletionClick(share)" class="secondary">
+                <Undo2 />
+                {{ $t('share.button.undoDeletion') }}
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>
@@ -492,5 +586,56 @@ td {
   margin-right: 5px;
   vertical-align: middle;
   opacity: 0.7;
+}
+
+.pending-deletion-section {
+  margin-top: 2rem;
+  border-top: 2px solid var(--panel-section-background-color-alt);
+  padding-top: 1rem;
+}
+
+.pending-deletion-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--panel-section-text-color);
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+
+  svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    opacity: 0.7;
+  }
+}
+
+.pending-deletion-description {
+  font-size: 0.8rem;
+  color: var(--panel-section-text-color);
+  opacity: 0.7;
+  margin-bottom: 0.75rem;
+}
+
+.pending-deletion-row {
+  opacity: 0.8;
+}
+
+.pending-deletion-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.65rem;
+  color: var(--panel-section-text-color);
+  background: var(--panel-section-background-color-alt);
+  border-radius: 4px;
+  padding: 2px 6px;
+  margin-top: 4px;
+  opacity: 0.8;
+
+  svg {
+    width: 0.75rem;
+    height: 0.75rem;
+  }
 }
 </style>

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -976,7 +976,11 @@
   "share": {
     "button": {
       "expireNow": "Jetzt ablaufen lassen",
-      "extend": "Verlängern"
+      "extend": "Verlängern",
+      "requestDeletion": "Request Deletion",
+      "undoDeletion": "Undo Deletion",
+      "deleteImmediately": "Delete Immediately",
+      "removeEntry": "Remove Entry"
     },
     "contains": {
       "count": "{value, plural, one {Enthält: # Datei} other {Enthält: {value} Dateien}}"

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -526,7 +526,8 @@
     },
     "close": "Schließen",
     "confirm": {
-      "pruneExpiredShares": "Sind Sie sicher, dass Sie Ihre abgelaufenen geteilten Dateien löschen wollen? Dies kann nicht rückgängig gemacht werden."
+      "pruneExpiredShares": "Sind Sie sicher, dass Sie Ihre abgelaufenen geteilten Dateien löschen wollen? Dies kann nicht rückgängig gemacht werden.",
+      "requestDeletion": "Are you sure you want to request deletion of this share? The share link will stop working immediately."
     },
     "description": {
       "about": "Informationen über Ihre Erugo-Installation",
@@ -567,7 +568,9 @@
     "error": {
       "pruneExpiredShares": "Abgelaufene geteilte Dateien konnten nicht zur Löschung eingeplant werden!",
       "shareExpired": "Geteilte Dateien konnten nicht auf \"abgelaufen\" gesetzt werden",
-      "shareExtended": "Geteilte Dateien konnten nicht auf \"verlängern\" gesetzt werden"
+      "shareExtended": "Geteilte Dateien konnten nicht auf \"verlängern\" gesetzt werden",
+      "requestDeletion": "Failed to request share deletion",
+      "undoDeletion": "Failed to undo share deletion request"
     },
     "help": {
       "auth_provider": {
@@ -702,7 +705,9 @@
     "success": {
       "pruneExpiredShares": "Abgelaufene geteilten Dateien sind zur Löschung vorgesehen und werden im Hintergrund verarbeitet.",
       "shareExpired": "Der Zeitraum zum Download der geteilten Dateien ist abgelaufen",
-      "shareExtended": "Der Zeitraum zum Download der geteilten Dateien wurde verlängert"
+      "shareExtended": "Der Zeitraum zum Download der geteilten Dateien wurde verlängert",
+      "requestDeletion": "Share deletion requested",
+      "undoDeletion": "Share deletion request cancelled"
     },
     "system": {
       "allow_chunked_uploads": "Chunked-Upload-Modus zulassen",
@@ -1006,7 +1011,10 @@
     },
     "not_found": "Die von Ihnen gesuchte Aktie wurde nicht gefunden. Möglicherweise müssen Sie sich anmelden, um sie zu sehen.",
     "passwordNotProtected": "Öffnen Sie",
-    "passwordProtected": "Passwort geschützt"
+    "passwordProtected": "Passwort geschützt",
+    "status": {
+      "pendingDeletion": "Pending Deletion"
+    }
   },
   "total_size": "Gesamtgröße",
   "upload": {

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -584,6 +584,18 @@
     },
     "loading": "Geteilte Dateien laden...",
     "noShares": "Sie haben keine geteilten Dateien. Warum nicht eine anlegen?",
+    "pendingDeletion": {
+      "title": "Löschung ausstehend",
+      "description": "Für die folgenden Shares wurde eine Löschung beantragt. Sie können dies rückgängig machen, bevor sie dauerhaft entfernt werden.",
+      "requestedOn": "Beantragt am",
+      "deleteAll": "Alle dauerhaft löschen",
+      "confirmPrompt": "Geben Sie DELETE (Großbuchstaben) ein, um alle ausstehenden Shares und ihre Dateien dauerhaft zu entfernen. Dies kann nicht rückgängig gemacht werden.",
+      "confirmMismatch": "Bestätigung stimmte nicht überein — Sie müssen DELETE in Großbuchstaben eingeben."
+    },
+    "expiredShares": {
+      "title": "{count, plural, one {1 abgelaufener Share} other {# abgelaufene Shares}}",
+      "notice": "Diese Shares sind abgelaufen und die Dateien sind noch auf dem Datenträger gespeichert. Um sie zu entfernen, wählen Sie im Aktionsmenü des Shares 'Löschung beantragen'."
+    },
     "provider": {
       "edit": "Bearbeiten",
       "view": "Ansehen"

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -611,7 +611,7 @@
       "requestedOn": "Requested On",
       "deleteAll": "Delete all permanently",
       "confirmPrompt": "Type DELETE (uppercase) to permanently remove all pending shares and their files. This cannot be undone.",
-      "confirmMismatch": "Confirmation did not match \u2014 you must type DELETE in uppercase exactly."
+      "confirmMismatch": "Confirmation did not match — you must type DELETE in uppercase exactly."
     },
     "expiredShares": {
       "title": "{count, plural, one {1 expired share} other {# expired shares}}",
@@ -997,7 +997,11 @@
   "share": {
     "button": {
       "expireNow": "Expire Now",
-      "extend": "Extend"
+      "extend": "Extend",
+      "requestDeletion": "Request Deletion",
+      "undoDeletion": "Undo Deletion",
+      "deleteImmediately": "Delete Immediately",
+      "removeEntry": "Remove Entry"
     },
     "contains": {
       "count": "{value, plural, one {# file} other {{value} files}}"

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -547,7 +547,8 @@
     },
     "close": "Close",
     "confirm": {
-      "pruneExpiredShares": "Are you sure you want to delete your expired shares? This cannot be undone."
+      "pruneExpiredShares": "Are you sure you want to delete your expired shares? This cannot be undone.",
+      "requestDeletion": "Are you sure you want to request deletion of this share? The share link will stop working immediately."
     },
     "description": {
       "about": "Information about your Erugo installation",
@@ -588,7 +589,9 @@
     "error": {
       "pruneExpiredShares": "Failed to schedule expired shares for deletion!",
       "shareExpired": "Failed to expire share",
-      "shareExtended": "Failed to extend share"
+      "shareExtended": "Failed to extend share",
+      "requestDeletion": "Failed to request share deletion",
+      "undoDeletion": "Failed to undo share deletion request"
     },
     "help": {
       "auth_provider": {
@@ -723,7 +726,9 @@
     "success": {
       "pruneExpiredShares": "Expired shares have been scheduled for deletion and will be processed in the background.",
       "shareExpired": "Share expired",
-      "shareExtended": "Share extended"
+      "shareExtended": "Share extended",
+      "requestDeletion": "Share deletion requested",
+      "undoDeletion": "Share deletion request cancelled"
     },
     "system": {
       "allow_chunked_uploads": "Allow chunked upload mode",
@@ -1002,6 +1007,9 @@
       "undoDeletion": "Undo Deletion",
       "deleteImmediately": "Delete Immediately",
       "removeEntry": "Remove Entry"
+    },
+    "status": {
+      "pendingDeletion": "Pending Deletion"
     },
     "contains": {
       "count": "{value, plural, one {# file} other {{value} files}}"

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -605,6 +605,18 @@
     },
     "loading": "Shares loading...",
     "noShares": "You have no shares. Why not create one?",
+    "pendingDeletion": {
+      "title": "Pending Deletion",
+      "description": "The following shares have been requested for deletion. You can undo this before they are permanently removed.",
+      "requestedOn": "Requested On",
+      "deleteAll": "Delete all permanently",
+      "confirmPrompt": "Type DELETE (uppercase) to permanently remove all pending shares and their files. This cannot be undone.",
+      "confirmMismatch": "Confirmation did not match \u2014 you must type DELETE in uppercase exactly."
+    },
+    "expiredShares": {
+      "title": "{count, plural, one {1 expired share} other {# expired shares}}",
+      "notice": "These shares have expired and their files are still stored on disk. To remove them, select 'Request Deletion' from the share's action menu."
+    },
     "provider": {
       "edit": "Edit",
       "view": "View"

--- a/resources/js/i18n/fr.json
+++ b/resources/js/i18n/fr.json
@@ -976,7 +976,11 @@
   "share": {
     "button": {
       "expireNow": "Expirer maintenant",
-      "extend": "Prolonger"
+      "extend": "Prolonger",
+      "requestDeletion": "Request Deletion",
+      "undoDeletion": "Undo Deletion",
+      "deleteImmediately": "Delete Immediately",
+      "removeEntry": "Remove Entry"
     },
     "contains": {
       "count": "{value, plural, one {Contient : fichier} other {Contient : fichiers {value}}}"

--- a/resources/js/i18n/fr.json
+++ b/resources/js/i18n/fr.json
@@ -584,6 +584,18 @@
     },
     "loading": "Chargement des partages...",
     "noShares": "Vous n'avez pas de partages. Pourquoi ne pas en créer un ?",
+    "pendingDeletion": {
+      "title": "Suppression en attente",
+      "description": "Les partages suivants ont été demandés pour suppression. Vous pouvez annuler cela avant qu'ils soient définitivement supprimés.",
+      "requestedOn": "Demandé le",
+      "deleteAll": "Tout supprimer définitivement",
+      "confirmPrompt": "Saisissez DELETE (en majuscules) pour supprimer définitivement tous les partages en attente et leurs fichiers. Cette action est irréversible.",
+      "confirmMismatch": "La confirmation ne correspond pas — vous devez saisir DELETE en majuscules exactement."
+    },
+    "expiredShares": {
+      "title": "{count, plural, one {1 partage expiré} other {# partages expirés}}",
+      "notice": "Ces partages ont expiré et leurs fichiers sont toujours stockés sur le disque. Pour les supprimer, sélectionnez 'Demander la suppression' dans le menu d'actions du partage."
+    },
     "provider": {
       "edit": "Editer",
       "view": "Voir"

--- a/resources/js/i18n/fr.json
+++ b/resources/js/i18n/fr.json
@@ -526,7 +526,8 @@
     },
     "close": "Fermer",
     "confirm": {
-      "pruneExpiredShares": "Êtes-vous sûr de vouloir supprimer vos partages expirés ? Cette opération ne peut pas être annulée."
+      "pruneExpiredShares": "Êtes-vous sûr de vouloir supprimer vos partages expirés ? Cette opération ne peut pas être annulée.",
+      "requestDeletion": "Are you sure you want to request deletion of this share? The share link will stop working immediately."
     },
     "description": {
       "about": "Informations sur votre installation Erugo",
@@ -567,7 +568,9 @@
     "error": {
       "pruneExpiredShares": "Impossible de planifier la suppression des partages expirés !",
       "shareExpired": "Échec de l'expiration du partage",
-      "shareExtended": "Échec de la prolongation du partage"
+      "shareExtended": "Échec de la prolongation du partage",
+      "requestDeletion": "Failed to request share deletion",
+      "undoDeletion": "Failed to undo share deletion request"
     },
     "help": {
       "auth_provider": {
@@ -702,7 +705,9 @@
     "success": {
       "pruneExpiredShares": "Les partages expirés ont été programmées pour être supprimées et seront traités en arrière-plan.",
       "shareExpired": "Partage expiré",
-      "shareExtended": "Partage étendu"
+      "shareExtended": "Partage étendu",
+      "requestDeletion": "Share deletion requested",
+      "undoDeletion": "Share deletion request cancelled"
     },
     "system": {
       "allow_chunked_uploads": "Autoriser le mode de téléchargement en morceaux",
@@ -1006,7 +1011,10 @@
     },
     "not_found": "Le partage que vous recherchez n'a pas été trouvé. Il se peut que vous deviez vous connecter pour le voir.",
     "passwordNotProtected": "Ouvert",
-    "passwordProtected": "Protégé par un mot de passe"
+    "passwordProtected": "Protégé par un mot de passe",
+    "status": {
+      "pendingDeletion": "Pending Deletion"
+    }
   },
   "total_size": "Taille totale",
   "upload": {

--- a/resources/js/i18n/it.json
+++ b/resources/js/i18n/it.json
@@ -584,6 +584,18 @@
     },
     "loading": "Caricamento delle condivisioni...",
     "noShares": "Non sono presenti condivisioni. Perché non ne crei una?",
+    "pendingDeletion": {
+      "title": "Eliminazione in attesa",
+      "description": "Le seguenti condivisioni sono state richieste per l'eliminazione. È possibile annullare prima che vengano rimosse definitivamente.",
+      "requestedOn": "Richiesto il",
+      "deleteAll": "Elimina tutto definitivamente",
+      "confirmPrompt": "Digita DELETE (maiuscolo) per rimuovere definitivamente tutte le condivisioni in attesa e i relativi file. Questa azione non può essere annullata.",
+      "confirmMismatch": "La conferma non corrisponde — devi digitare DELETE in maiuscolo esattamente."
+    },
+    "expiredShares": {
+      "title": "{count, plural, one {1 condivisione scaduta} other {# condivisioni scadute}}",
+      "notice": "Queste condivisioni sono scadute e i loro file sono ancora memorizzati sul disco. Per rimuoverli, seleziona 'Richiedi eliminazione' dal menu azioni della condivisione."
+    },
     "provider": {
       "edit": "Modifica",
       "view": "Visualizza"

--- a/resources/js/i18n/it.json
+++ b/resources/js/i18n/it.json
@@ -526,7 +526,8 @@
     },
     "close": "Chiudi",
     "confirm": {
-      "pruneExpiredShares": "Sei sicuro di voler eliminare le condivisioni scadute? Non è possibile annullare questa operazione."
+      "pruneExpiredShares": "Sei sicuro di voler eliminare le condivisioni scadute? Non è possibile annullare questa operazione.",
+      "requestDeletion": "Are you sure you want to request deletion of this share? The share link will stop working immediately."
     },
     "description": {
       "about": "Informazioni sull'installazione di Erugo",
@@ -567,7 +568,9 @@
     "error": {
       "pruneExpiredShares": "Impossibile pianificare l'eliminazione delle condivisioni scadute!",
       "shareExpired": "Condivisione non scaduta",
-      "shareExtended": "Impossibile estendere la condivisione"
+      "shareExtended": "Impossibile estendere la condivisione",
+      "requestDeletion": "Failed to request share deletion",
+      "undoDeletion": "Failed to undo share deletion request"
     },
     "help": {
       "auth_provider": {
@@ -702,7 +705,9 @@
     "success": {
       "pruneExpiredShares": "Le condivisioni scadute sono state contrassegnate per l'eliminazione e verranno elaborate in background.",
       "shareExpired": "Quota scaduta",
-      "shareExtended": "Quota estesa"
+      "shareExtended": "Quota estesa",
+      "requestDeletion": "Share deletion requested",
+      "undoDeletion": "Share deletion request cancelled"
     },
     "system": {
       "allow_chunked_uploads": "Consentire la modalità di caricamento chunked",
@@ -1006,7 +1011,10 @@
     },
     "not_found": "La condivisione che si sta cercando non è stata trovata. Potrebbe essere necessario effettuare il login per visualizzarla.",
     "passwordNotProtected": "Aperto",
-    "passwordProtected": "Protetto da password"
+    "passwordProtected": "Protetto da password",
+    "status": {
+      "pendingDeletion": "Pending Deletion"
+    }
   },
   "total_size": "Dimensione totale",
   "upload": {

--- a/resources/js/i18n/it.json
+++ b/resources/js/i18n/it.json
@@ -976,7 +976,11 @@
   "share": {
     "button": {
       "expireNow": "Scadere ora",
-      "extend": "Estendere"
+      "extend": "Estendere",
+      "requestDeletion": "Request Deletion",
+      "undoDeletion": "Undo Deletion",
+      "deleteImmediately": "Delete Immediately",
+      "removeEntry": "Remove Entry"
     },
     "contains": {
       "count": "{value, plural, one {Contiene: 1 File} other {Contiene: {value} File} }"

--- a/resources/js/i18n/nl.json
+++ b/resources/js/i18n/nl.json
@@ -584,6 +584,18 @@
     },
     "loading": "Aandelen uploaden...",
     "noShares": "Er zijn geen aandelen. Maak er een!",
+    "pendingDeletion": {
+      "title": "Verwijdering in behandeling",
+      "description": "Voor de volgende shares is verwijdering aangevraagd. U kunt dit ongedaan maken voordat ze permanent worden verwijderd.",
+      "requestedOn": "Aangevraagd op",
+      "deleteAll": "Alles definitief verwijderen",
+      "confirmPrompt": "Typ DELETE (hoofdletters) om alle wachtende shares en hun bestanden permanent te verwijderen. Dit kan niet ongedaan worden gemaakt.",
+      "confirmMismatch": "Bevestiging komt niet overeen — u moet DELETE exact in hoofdletters typen."
+    },
+    "expiredShares": {
+      "title": "{count, plural, one {1 verlopen share} other {# verlopen shares}}",
+      "notice": "Deze shares zijn verlopen en hun bestanden staan nog steeds op schijf. Om ze te verwijderen, selecteer 'Verwijdering aanvragen' in het actiemenu van de share."
+    },
     "provider": {
       "edit": "Bewerk",
       "view": "Bekijk"

--- a/resources/js/i18n/nl.json
+++ b/resources/js/i18n/nl.json
@@ -976,7 +976,11 @@
   "share": {
     "button": {
       "expireNow": "Nu verlopen",
-      "extend": "Verleng"
+      "extend": "Verleng",
+      "requestDeletion": "Request Deletion",
+      "undoDeletion": "Undo Deletion",
+      "deleteImmediately": "Delete Immediately",
+      "removeEntry": "Remove Entry"
     },
     "contains": {
       "count": "{value, plural, one {Bevat: # bestand} other {Bevat: {value} bestanden}}"

--- a/resources/js/i18n/nl.json
+++ b/resources/js/i18n/nl.json
@@ -526,7 +526,8 @@
     },
     "close": "Sluit",
     "confirm": {
-      "pruneExpiredShares": "Weet je zeker dat je verlopen aandelen wilt verwijderen? Het is niet mogelijk om deze bewerking ongedaan te maken."
+      "pruneExpiredShares": "Weet je zeker dat je verlopen aandelen wilt verwijderen? Het is niet mogelijk om deze bewerking ongedaan te maken.",
+      "requestDeletion": "Are you sure you want to request deletion of this share? The share link will stop working immediately."
     },
     "description": {
       "about": "Informatie over uw Erugo installatie",
@@ -567,7 +568,9 @@
     "error": {
       "pruneExpiredShares": "Kan verwijdering van verlopen aandelen niet plannen!",
       "shareExpired": "Delen niet verlopen",
-      "shareExtended": "Niet gelukt om aandeel uit te breiden"
+      "shareExtended": "Niet gelukt om aandeel uit te breiden",
+      "requestDeletion": "Failed to request share deletion",
+      "undoDeletion": "Failed to undo share deletion request"
     },
     "help": {
       "auth_provider": {
@@ -702,7 +705,9 @@
     "success": {
       "pruneExpiredShares": "Vervallen aandelen zijn gemarkeerd voor verwijdering en worden op de achtergrond verwerkt.",
       "shareExpired": "Aandeel verlopen",
-      "shareExtended": "Aandeel uitgebreid"
+      "shareExtended": "Aandeel uitgebreid",
+      "requestDeletion": "Share deletion requested",
+      "undoDeletion": "Share deletion request cancelled"
     },
     "system": {
       "allow_chunked_uploads": "Opgedeelde bestands upload toestaan",
@@ -1006,7 +1011,10 @@
     },
     "not_found": "Het aandeel dat u zoekt is niet gevonden. Mogelijk moet u inloggen om het te zien.",
     "passwordNotProtected": "Open",
-    "passwordProtected": "Wachtwoord beveiligd"
+    "passwordProtected": "Wachtwoord beveiligd",
+    "status": {
+      "pendingDeletion": "Pending Deletion"
+    }
   },
   "total_size": "Totale grootte",
   "upload": {

--- a/resources/js/i18n/pt-BR.json
+++ b/resources/js/i18n/pt-BR.json
@@ -4,6 +4,18 @@
       "auth_providers_description_localhost": "A configuração de autenticação externa não está disponível no localhost. Os provedores OAuth exigem um nome de domínio totalmente qualificado (FQDN) para funcionar corretamente. Aceda ao Erugo através de um domínio registado para configurar estas definições.",
       "callback_url": "URL de chamada de retorno",
       "callback_url_description": "Utilize o URL de retorno de chamada fornecido na configuração do seu fornecedor de identidade."
+    },
+    "pendingDeletion": {
+      "title": "Exclusão pendente",
+      "description": "Os compartilhamentos a seguir foram solicitados para exclusão. Você pode desfazer isso antes que sejam removidos permanentemente.",
+      "requestedOn": "Solicitado em",
+      "deleteAll": "Excluir tudo permanentemente",
+      "confirmPrompt": "Digite DELETE (maiúsculas) para remover permanentemente todos os compartilhamentos pendentes e seus arquivos. Isso não pode ser desfeito.",
+      "confirmMismatch": "Confirmação não corresponde — você deve digitar DELETE em maiúsculas exatamente."
+    },
+    "expiredShares": {
+      "title": "{count, plural, one {1 compartilhamento expirado} other {# compartilhamentos expirados}}",
+      "notice": "Esses compartilhamentos expiraram e seus arquivos ainda estão armazenados no disco. Para removê-los, selecione 'Solicitar exclusão' no menu de ações do compartilhamento."
     }
   }
 }

--- a/resources/js/i18n/pt-BR.json
+++ b/resources/js/i18n/pt-BR.json
@@ -16,6 +16,22 @@
     "expiredShares": {
       "title": "{count, plural, one {1 compartilhamento expirado} other {# compartilhamentos expirados}}",
       "notice": "Esses compartilhamentos expiraram e seus arquivos ainda estão armazenados no disco. Para removê-los, selecione 'Solicitar exclusão' no menu de ações do compartilhamento."
+    },
+    "confirm": {
+      "requestDeletion": "Are you sure you want to request deletion of this share? The share link will stop working immediately."
+    },
+    "error": {
+      "requestDeletion": "Failed to request share deletion",
+      "undoDeletion": "Failed to undo share deletion request"
+    },
+    "success": {
+      "requestDeletion": "Share deletion requested",
+      "undoDeletion": "Share deletion request cancelled"
+    }
+  },
+  "share": {
+    "status": {
+      "pendingDeletion": "Pending Deletion"
     }
   }
 }

--- a/resources/js/i18n/pt.json
+++ b/resources/js/i18n/pt.json
@@ -947,7 +947,11 @@
   "share": {
     "button": {
       "expireNow": "Expirar Agora",
-      "extend": "Extender"
+      "extend": "Extender",
+      "requestDeletion": "Request Deletion",
+      "undoDeletion": "Undo Deletion",
+      "deleteImmediately": "Delete Immediately",
+      "removeEntry": "Remove Entry"
     },
     "contains": {
       "count": "{value, plural, one {Contém: # ficheiro} other {Contém: {value} ficheiros} }"

--- a/resources/js/i18n/pt.json
+++ b/resources/js/i18n/pt.json
@@ -563,6 +563,18 @@
     },
     "loading": "Carregando as transferências...",
     "noShares": "Não tem transferências. Porque não criar uma?",
+    "pendingDeletion": {
+      "title": "Eliminação pendente",
+      "description": "As seguintes partilhas foram solicitadas para eliminação. Pode desfazer isto antes de serem removidas permanentemente.",
+      "requestedOn": "Solicitado em",
+      "deleteAll": "Eliminar tudo permanentemente",
+      "confirmPrompt": "Escreva DELETE (maiúsculas) para remover permanentemente todas as partilhas pendentes e os seus ficheiros. Esta ação não pode ser desfeita.",
+      "confirmMismatch": "Confirmação não corresponde — deve escrever DELETE em maiúsculas exatamente."
+    },
+    "expiredShares": {
+      "title": "{count, plural, one {1 partilha expirada} other {# partilhas expiradas}}",
+      "notice": "Estas partilhas expiraram e os seus ficheiros ainda estão armazenados no disco. Para os remover, selecione 'Solicitar eliminação' no menu de ações da partilha."
+    },
     "provider": {
       "edit": "Editar",
       "view": "Ver"

--- a/resources/js/i18n/pt.json
+++ b/resources/js/i18n/pt.json
@@ -505,7 +505,8 @@
     },
     "close": "Fechar",
     "confirm": {
-      "pruneExpiredShares": "Tem a certeza de que pretende eliminar as suas transferências expiradas? Não as poderá recuperar."
+      "pruneExpiredShares": "Tem a certeza de que pretende eliminar as suas transferências expiradas? Não as poderá recuperar.",
+      "requestDeletion": "Are you sure you want to request deletion of this share? The share link will stop working immediately."
     },
     "description": {
       "about": "Informações sobre a sua instalação Erugo",
@@ -546,7 +547,9 @@
     "error": {
       "pruneExpiredShares": "Falha ao agendar a eliminação das transferências expiradas!",
       "shareExpired": "Falha ao expirar a partilha",
-      "shareExtended": "Falha ao extender a partilha"
+      "shareExtended": "Falha ao extender a partilha",
+      "requestDeletion": "Failed to request share deletion",
+      "undoDeletion": "Failed to undo share deletion request"
     },
     "help": {
       "auth_provider": {
@@ -681,7 +684,9 @@
     "success": {
       "pruneExpiredShares": "As transferências expiradas foram agendadas para eliminação e serão processadas em segundo plano.",
       "shareExpired": "Partilha expirada",
-      "shareExtended": "Partilha extendida"
+      "shareExtended": "Partilha extendida",
+      "requestDeletion": "Share deletion requested",
+      "undoDeletion": "Share deletion request cancelled"
     },
     "system": {
       "allow_chunked_uploads": "Permitir o modo de carregamento em pedaços",
@@ -977,7 +982,10 @@
     },
     "not_found": "A partilha que procura não foi encontrada. Poderá ser necessário iniciar sessão para a ver.",
     "passwordNotProtected": "Aberto",
-    "passwordProtected": "Protegido por palavra-passe"
+    "passwordProtected": "Protegido por palavra-passe",
+    "status": {
+      "pendingDeletion": "Pending Deletion"
+    }
   },
   "total_size": "Tamanho Total",
   "upload": {

--- a/routes/api.php
+++ b/routes/api.php
@@ -138,6 +138,9 @@ Route::group([], function ($router) {
 
         //undo a pending deletion request
         Route::post('/{id}/undo-deletion', [SharesController::class, 'undoDeletion'])->name('shares.undoDeletion');
+
+        //permanently remove the DB record of a deleted share (owner or admin)
+        Route::delete('/{id}', [SharesController::class, 'purgeShare'])->name('shares.purge');
     });
 
     //all shares [auth, admin]

--- a/routes/api.php
+++ b/routes/api.php
@@ -144,6 +144,9 @@ Route::group([], function ($router) {
     Route::group(['prefix' => 'shares', 'middleware' => ['auth', Admin::class]], function ($router) {
         //get all shares (admin only)
         Route::get('/all', [SharesController::class, 'allShares'])->name('shares.allShares');
+
+        //immediately delete a share's files (admin only, requires typed confirmation)
+        Route::post('/{id}/delete-immediately', [SharesController::class, 'deleteImmediately'])->name('shares.deleteImmediately');
     });
 
     //manage themes [auth, admin]

--- a/routes/api.php
+++ b/routes/api.php
@@ -132,6 +132,12 @@ Route::group([], function ($router) {
 
         //prune expired shares
         Route::post('/prune-expired', [SharesController::class, 'pruneExpiredShares'])->name('shares.pruneExpired');
+
+        //request early deletion of a share (user or admin)
+        Route::post('/{id}/request-deletion', [SharesController::class, 'requestDeletion'])->name('shares.requestDeletion');
+
+        //undo a pending deletion request
+        Route::post('/{id}/undo-deletion', [SharesController::class, 'undoDeletion'])->name('shares.undoDeletion');
     });
 
     //all shares [auth, admin]

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,7 @@ use App\Models\Theme;
 use App\Http\Controllers\ExternalAuthController;
 use App\Services\SettingsService;
 
+if (!function_exists('getSettings')) {
 function getSettings()
 {
     
@@ -50,6 +51,7 @@ function getSettings()
 
     return $indexedSettings;
 }
+} // end if (!function_exists('getSettings'))
 
 Route::get('/', function () {
     $indexedSettings = getSettings();

--- a/tests/F4_PENDING_DELETION_TEST_RESULTS.md
+++ b/tests/F4_PENDING_DELETION_TEST_RESULTS.md
@@ -1,0 +1,115 @@
+# F4: Share Pending Deletion — Test Results
+
+**Branch:** `feature/share-pending-deletion`
+**Run date:** 2026-07-11 UTC
+**Platform:** Linux x86_64 (Kali)
+
+---
+
+## Changes Under Test
+
+| File | Change |
+|---|---|
+| `database/migrations/2026_07_11_200000_add_pending_deletion_to_shares_table.php` | Adds `deletion_requested_at` (timestamp, nullable) and `deletion_requested_by` (string 10, nullable) to shares |
+| `app/Models/Share.php` | Adds `pending_deletion` to `$appends`/`$fillable`/`$casts`; adds `getPendingDeletionAttribute()` |
+| `app/Http/Controllers/SharesController.php` | Blocks `pending_deletion` in `read()` and `download()`; adds `requestDeletion()` and `undoDeletion()` |
+| `app/Jobs/sendDeletionWarningEmails.php` | Excludes `pending_deletion` shares from deletion warning query |
+| `app/Jobs/sendExpiryWarningEmails.php` | Excludes `pending_deletion` shares from expiry warning query |
+| `app/Jobs/sendExpiredWarningEmails.php` | Excludes `pending_deletion` shares from expired warning query |
+| `routes/api.php` | Adds `POST /{id}/request-deletion` and `POST /{id}/undo-deletion` routes (auth middleware) |
+| `resources/js/api.js` | Adds `requestShareDeletion()` and `undoShareDeletion()` |
+| `resources/js/components/settings/myShares.vue` | Splits shares into activeShares/pendingDeletionShares computed; adds "Request deletion" button; adds pending deletion section (conditional on non-empty) with undo button |
+| `resources/js/components/settings/allShares.vue` | Adds pending_deletion badge with requester label; adds request/undo deletion buttons for admin |
+
+---
+
+## Test Script
+
+**Script:** `tests/scripts/test_share_pending_deletion.php`
+**Runner:** `php tests/scripts/test_share_pending_deletion.php`
+
+Mirrors `requestDeletion()`, `undoDeletion()`, access guard (`isAccessible()`), and email suppression logic as standalone PHP functions. No Laravel runtime or composer vendor required.
+
+---
+
+## Output
+
+```
+=================================================================
+F4: Share Pending Deletion — Test Suite
+=================================================================
+
+-- State machine: requestDeletion() --
+
+PASS: Owner can request deletion of own share — status OK
+PASS: Status set to pending_deletion
+PASS: deletion_requested_by = user
+PASS: deletion_requested_at is set
+PASS: share is now pending deletion
+PASS: Admin can request deletion of any share
+PASS: deletion_requested_by = admin when admin requests
+PASS: Non-owner cannot request deletion
+PASS: Non-owner gets 401
+PASS: Share status unchanged after unauthorized request
+PASS: Cannot double-request deletion
+PASS: Double-request returns 422
+PASS: Cannot request deletion of already-deleted share
+PASS: Already-deleted returns 422
+
+-- State machine: undoDeletion() --
+
+PASS: Owner can undo deletion of own share
+PASS: Status restored to ready
+PASS: deletion_requested_at cleared
+PASS: deletion_requested_by cleared
+PASS: Share is no longer pending deletion
+PASS: Admin can undo deletion on any share
+PASS: Cannot undo deletion of non-pending share
+PASS: Non-pending undo returns 422
+PASS: Non-owner cannot undo deletion
+PASS: Non-owner undo returns 401
+
+-- Access control: read() / download() --
+
+PASS: Active share is accessible
+PASS: Pending deletion share is not accessible
+PASS: Deleted share is not accessible
+PASS: Expired-but-ready share passes the pending_deletion gate (expiry checked separately)
+
+-- Email suppression: warning emails skip pending_deletion --
+
+PASS: Ready share receives expiry warning
+PASS: Pending deletion share suppressed from expiry warning
+PASS: Deleted share suppressed from expiry warning
+
+-- Round-trip: request then undo then re-request --
+
+PASS: Round-trip step 1: request deletion succeeds
+PASS: Round-trip step 2: undo succeeds
+PASS: Round-trip step 2: status back to ready
+PASS: Round-trip step 3: can request deletion again after undo
+PASS: Round-trip step 3: status is pending_deletion again
+
+-- Negative tests --
+
+PASS: Pending (zip building) share can be requested for deletion
+PASS: Failed share can be requested for deletion
+
+=================================================================
+Results: 38 passed, 0 failed
+All tests passed.
+```
+
+---
+
+## Summary
+
+| Test group | Tests | Pass | Fail |
+|---|---|---|---|
+| requestDeletion() state machine | 14 | 14 | 0 |
+| undoDeletion() state machine | 10 | 10 | 0 |
+| Access control (read/download gate) | 4 | 4 | 0 |
+| Email suppression | 3 | 3 | 0 |
+| Round-trip (request → undo → re-request) | 5 | 5 | 0 |
+| Negative tests (non-ready statuses) | 2 | 2 | 0 |
+| **Total** | **38** | **38** | **0** |

--- a/tests/F5_ADMIN_DELETION_TEST_RESULTS.md
+++ b/tests/F5_ADMIN_DELETION_TEST_RESULTS.md
@@ -1,0 +1,100 @@
+# F5: Admin Immediate Share Deletion — Test Results
+
+**Branch:** `feature/admin-share-deletion`
+**Run date:** 2026-07-11 UTC
+**Platform:** Linux x86_64 (Kali)
+
+---
+
+## Changes Under Test
+
+| File | Change |
+|---|---|
+| `app/Http/Controllers/SharesController.php` | Adds `deleteImmediately()` — admin-only, typed confirmation, calls `cleanFiles()` on pending_deletion or expired shares |
+| `app/Jobs/cleanExpiredShares.php` | Also processes `pending_deletion` shares in the scheduled cleanup run |
+| `routes/api.php` | Adds `POST /shares/{id}/delete-immediately` (admin middleware) |
+| `resources/js/api.js` | Adds `deleteShareImmediately(id, confirmation)` |
+| `resources/js/components/settings/allShares.vue` | Adds "Delete immediately" button (shown for pending_deletion and expired shares); `prompt()` confirmation dialog; `canDeleteImmediately()` eligibility helper |
+
+---
+
+## Test Script
+
+**Script:** `tests/scripts/test_admin_share_deletion.php`
+**Runner:** `php tests/scripts/test_admin_share_deletion.php`
+
+---
+
+## Output
+
+```
+=================================================================
+F5: Admin Immediate Share Deletion — Test Suite
+=================================================================
+
+-- Authorization: admin-only --
+
+PASS: Non-admin cannot call deleteImmediately
+PASS: Non-admin gets 401
+PASS: Non-admin attempt does not clean files
+PASS: Admin can call deleteImmediately
+PASS: Admin attempt cleans files
+PASS: Share status set to deleted
+
+-- Confirmation phrase --
+
+PASS: No confirmation → error
+PASS: Empty string → error
+PASS: Wrong word → error
+PASS: Partial match → error
+PASS: "delete" (lowercase) → success
+PASS: "DELETE" (uppercase) → success (case-insensitive)
+PASS: "  delete  " (whitespace) → success (trimmed)
+
+-- Eligible share states --
+
+PASS: pending_deletion → can delete immediately
+PASS: expired ready share → can delete immediately
+PASS: active (non-expired) share → cannot delete immediately
+PASS: active share → 422
+PASS: already-deleted share → error
+PASS: already-deleted → 422
+
+-- canDeleteImmediately() Vue helper --
+
+PASS: pending_deletion → button shown
+PASS: expired ready → button shown
+PASS: active share → button hidden
+PASS: already deleted → button hidden
+
+-- cleanExpiredShares job: pending_deletion included --
+
+PASS: Job processes pending_deletion share even if not yet expired
+PASS: Job processes share expired past cleanup window (30d)
+PASS: Job skips share expired only recently (within 30d window)
+PASS: Job skips already-deleted shares
+PASS: Job skips active shares
+
+-- Idempotency: double-click guard --
+
+PASS: First delete succeeds
+PASS: Second delete on same share fails (already deleted)
+
+=================================================================
+Results: 30 passed, 0 failed
+All tests passed.
+```
+
+---
+
+## Summary
+
+| Test group | Tests | Pass | Fail |
+|---|---|---|---|
+| Authorization (admin-only) | 6 | 6 | 0 |
+| Confirmation phrase (case, whitespace, wrong values) | 7 | 7 | 0 |
+| Eligible share states (pending, expired, active, already-deleted) | 6 | 6 | 0 |
+| canDeleteImmediately() Vue helper | 4 | 4 | 0 |
+| cleanExpiredShares job — pending_deletion processing | 5 | 5 | 0 |
+| Idempotency (double-click guard) | 2 | 2 | 0 |
+| **Total** | **30** | **30** | **0** |

--- a/tests/Feature/AdminShareDeletionTest.php
+++ b/tests/Feature/AdminShareDeletionTest.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace Tests\Feature;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\Share;
+use App\Models\Setting;
+use Tests\TestCase;
+
+class AdminShareDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Disable deletion emails — sendEmail uses a custom SMTP mailer that
+        // requires live DB settings; suppressing it keeps tests self-contained.
+        Setting::updateOrCreate(
+            ['key' => 'emails_share_deleted_enabled'],
+            ['value' => '0', 'group' => 'emails']
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private function makeUser(bool $admin = false): User
+    {
+        return User::factory()->create(['admin' => $admin]);
+    }
+
+    private function makeShare(User $owner, array $attrs = []): Share
+    {
+        return Share::create(array_merge([
+            'user_id'        => $owner->id,
+            'name'           => 'Test Share',
+            'description'    => '',
+            'path'           => 'test/' . $owner->id . '/' . uniqid(),
+            'long_id'        => 'share-' . uniqid(),
+            'size'           => 0,
+            'file_count'     => 0,
+            'download_limit' => null,
+            'download_count' => 0,
+            'require_email'  => false,
+            'expires_at'     => Carbon::now()->addDays(30),
+            'status'         => 'ready',
+        ], $attrs));
+    }
+
+    private function deleteImmediatelyUrl(int $id): string
+    {
+        return "/api/shares/{$id}/delete-immediately";
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Authentication / authorisation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_request_is_rejected(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $response = $this->postJson($this->deleteImmediatelyUrl($share->id), [
+            'confirmation' => 'DELETE',
+        ]);
+
+        $this->assertNotEquals(200, $response->status());
+    }
+
+    public function test_non_admin_cannot_delete_immediately(): void
+    {
+        $owner = $this->makeUser(admin: false);
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), [
+                'confirmation' => 'DELETE',
+            ]);
+
+        $response->assertStatus(403);
+
+        $share->refresh();
+        $this->assertEquals('pending_deletion', $share->status);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Confirmation phrase
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_missing_confirmation_is_rejected(): void
+    {
+        $admin = $this->makeUser(admin: true);
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), []);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_wrong_confirmation_phrase_is_rejected(): void
+    {
+        $admin = $this->makeUser(admin: true);
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        foreach (['delete', 'yes', 'confirm', 'delet'] as $bad) {
+            $response = $this->actingAs($admin, 'sanctum')
+                ->postJson($this->deleteImmediatelyUrl($share->id), [
+                    'confirmation' => $bad,
+                ]);
+
+            $response->assertStatus(422, "Expected 422 for confirmation: '{$bad}'");
+        }
+    }
+
+    public function test_correct_uppercase_delete_confirmation_is_accepted(): void
+    {
+        $admin = $this->makeUser(admin: true);
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), [
+                'confirmation' => 'DELETE',
+            ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'success');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Eligible states
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_admin_can_delete_pending_deletion_share_immediately(): void
+    {
+        $admin = $this->makeUser(admin: true);
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), [
+                'confirmation' => 'DELETE',
+            ])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals('deleted', $share->status);
+    }
+
+    public function test_admin_can_delete_expired_share_immediately(): void
+    {
+        $admin = $this->makeUser(admin: true);
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, [
+            'status'     => 'ready',
+            'expires_at' => Carbon::now()->subHour(),
+        ]);
+
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), [
+                'confirmation' => 'DELETE',
+            ])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals('deleted', $share->status);
+    }
+
+    public function test_admin_cannot_delete_active_share_immediately(): void
+    {
+        $admin = $this->makeUser(admin: true);
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, [
+            'status'     => 'ready',
+            'expires_at' => Carbon::now()->addDays(30),
+        ]);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), [
+                'confirmation' => 'DELETE',
+            ]);
+
+        $response->assertStatus(422);
+
+        $share->refresh();
+        $this->assertEquals('ready', $share->status);
+    }
+
+    public function test_admin_cannot_delete_already_deleted_share(): void
+    {
+        $admin = $this->makeUser(admin: true);
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'deleted']);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), [
+                'confirmation' => 'DELETE',
+            ]);
+
+        $response->assertStatus(422);
+    }
+
+    public function test_delete_immediately_of_nonexistent_share_returns_404(): void
+    {
+        $admin = $this->makeUser(admin: true);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson('/api/shares/999999/delete-immediately', [
+                'confirmation' => 'DELETE',
+            ]);
+
+        $response->assertStatus(404);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Idempotency guard
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_double_delete_immediately_is_rejected(): void
+    {
+        $admin = $this->makeUser(admin: true);
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), ['confirmation' => 'DELETE'])
+            ->assertStatus(200);
+
+        // Second call: share is now 'deleted' — must be rejected
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), ['confirmation' => 'DELETE'])
+            ->assertStatus(422);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Workflow: F4 request → F5 delete-immediately
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_full_workflow_user_requests_then_admin_deletes(): void
+    {
+        $owner = $this->makeUser();
+        $admin = $this->makeUser(admin: true);
+        $share = $this->makeShare($owner);
+
+        // User marks for deletion
+        $this->actingAs($owner, 'sanctum')
+            ->postJson("/api/shares/{$share->id}/request-deletion")
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals('pending_deletion', $share->status);
+
+        // Admin immediately deletes
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->deleteImmediatelyUrl($share->id), ['confirmation' => 'DELETE'])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals('deleted', $share->status);
+    }
+}

--- a/tests/Feature/ExtendShareTest.php
+++ b/tests/Feature/ExtendShareTest.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace Tests\Feature;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\Share;
+use App\Models\Setting;
+use Tests\TestCase;
+
+class ExtendShareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private function makeUser(bool $admin = false): User
+    {
+        return User::factory()->create(['admin' => $admin]);
+    }
+
+    private function makeShare(User $owner, array $attrs = []): Share
+    {
+        return Share::create(array_merge([
+            'user_id'        => $owner->id,
+            'name'           => 'Test Share',
+            'description'    => '',
+            'path'           => 'test-path-' . uniqid(),
+            'long_id'        => 'share-' . uniqid(),
+            'size'           => 0,
+            'file_count'     => 0,
+            'download_limit' => null,
+            'download_count' => 0,
+            'require_email'  => false,
+            'expires_at'     => Carbon::now()->addDays(30),
+            'status'         => 'active',
+        ], $attrs));
+    }
+
+    private function setMaxExpiry(int $days): void
+    {
+        Setting::updateOrCreate(
+            ['key' => 'max_expiry_time'],
+            ['value' => (string) $days, 'group' => 'shares']
+        );
+    }
+
+    private function extendUrl(int $shareId): string
+    {
+        return "/api/shares/{$shareId}/extend";
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Authentication / authorisation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_request_is_rejected(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $response = $this->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'days']);
+
+        // Must not succeed — JWT guard may return 401, 302, or 500 depending on config
+        $this->assertNotEquals(200, $response->status(), 'Unauthenticated request must not succeed');
+    }
+
+    public function test_non_owner_cannot_extend_share(): void
+    {
+        $owner   = $this->makeUser();
+        $other   = $this->makeUser();
+        $share   = $this->makeShare($owner);
+
+        $response = $this->actingAs($other, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'days']);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_admin_can_extend_any_share(): void
+    {
+        $owner = $this->makeUser();
+        $admin = $this->makeUser(admin: true);
+        $share = $this->makeShare($owner);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'days']);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'success');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Relative extension — base-from-expiry bug regression
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_relative_extension_extends_from_current_expiry_not_now(): void
+    {
+        // Share expires 60 days from now; extending by 7 days should give ~67 days, not ~7 days
+        $owner  = $this->makeUser();
+        $future = Carbon::now()->addDays(60);
+        $share  = $this->makeShare($owner, ['expires_at' => $future]);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'days'])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $expected = $future->copy()->addDays(7);
+
+        // Allow 60-second tolerance for test execution time
+        $this->assertEqualsWithDelta(
+            $expected->timestamp,
+            $share->expires_at->timestamp,
+            60,
+            'Extension should be based on current expiry, not now()'
+        );
+    }
+
+    public function test_relative_extension_uses_now_as_base_when_share_is_expired(): void
+    {
+        $owner = $this->makeUser();
+        $past  = Carbon::now()->subDays(5);
+        $share = $this->makeShare($owner, ['expires_at' => $past]);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'days'])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $expected = Carbon::now()->addDays(7);
+
+        $this->assertEqualsWithDelta(
+            $expected->timestamp,
+            $share->expires_at->timestamp,
+            60,
+            'Expired share extension should be based on now()'
+        );
+    }
+
+    public function test_extend_by_weeks(): void
+    {
+        $owner = $this->makeUser();
+        $base  = Carbon::now()->addDays(10);
+        $share = $this->makeShare($owner, ['expires_at' => $base]);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 2, 'unit' => 'weeks'])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $expected = $base->copy()->addWeeks(2);
+
+        $this->assertEqualsWithDelta($expected->timestamp, $share->expires_at->timestamp, 60);
+    }
+
+    public function test_extend_by_months(): void
+    {
+        $owner = $this->makeUser();
+        $base  = Carbon::now()->addDays(10);
+        $share = $this->makeShare($owner, ['expires_at' => $base]);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 1, 'unit' => 'months'])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $expected = $base->copy()->addMonths(1);
+
+        $this->assertEqualsWithDelta($expected->timestamp, $share->expires_at->timestamp, 60);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Null expires_at (unlimited) — bug regression
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_extending_null_expiry_share_uses_now_as_base(): void
+    {
+        // Admin-set unlimited share (expires_at = null); extending should not crash
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['expires_at' => null]);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'days'])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $expected = Carbon::now()->addDays(7);
+
+        $this->assertEqualsWithDelta($expected->timestamp, $share->expires_at->timestamp, 60);
+    }
+
+    public function test_share_with_null_expiry_expired_attribute_is_false(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['expires_at' => null]);
+
+        $this->assertFalse($share->expired, 'Unlimited share must not be treated as expired');
+    }
+
+    public function test_share_with_null_expiry_deletes_at_is_null(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['expires_at' => null]);
+
+        $this->assertNull($share->deletes_at, 'Unlimited share must not have a deletes_at date');
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // max_expiry_time enforcement
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_extension_is_rejected_when_it_exceeds_max_expiry(): void
+    {
+        $this->setMaxExpiry(30);
+
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['expires_at' => Carbon::now()->addDays(28)]);
+
+        // 28 (current) + 7 = 35 days from now > 30 day max
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'days']);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('status', 'error');
+    }
+
+    public function test_extension_within_max_expiry_is_accepted(): void
+    {
+        $this->setMaxExpiry(30);
+
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['expires_at' => Carbon::now()->addDays(20)]);
+
+        // 20 (current) + 5 = 25 days from now ≤ 30 day max
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 5, 'unit' => 'days'])
+            ->assertStatus(200);
+    }
+
+    public function test_admin_bypasses_max_expiry_on_relative_extension(): void
+    {
+        $this->setMaxExpiry(30);
+
+        $owner = $this->makeUser();
+        $admin = $this->makeUser(admin: true);
+        $share = $this->makeShare($owner, ['expires_at' => Carbon::now()->addDays(28)]);
+
+        // Would exceed 30 days for a regular user, but admin should be allowed
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 30, 'unit' => 'days'])
+            ->assertStatus(200);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Admin-only options
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_admin_can_set_unlimited_expiry(): void
+    {
+        $owner = $this->makeUser();
+        $admin = $this->makeUser(admin: true);
+        $share = $this->makeShare($owner);
+
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['unlimited' => true])
+            ->assertStatus(200)
+            ->assertJsonPath('status', 'success');
+
+        $share->refresh();
+        $this->assertNull($share->expires_at, 'Admin unlimited should set expires_at to null');
+    }
+
+    public function test_admin_can_set_specific_date(): void
+    {
+        $owner  = $this->makeUser();
+        $admin  = $this->makeUser(admin: true);
+        $share  = $this->makeShare($owner);
+        $target = Carbon::now()->addDays(90)->toDateString();
+
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['expires_at' => $target])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals($target, $share->expires_at->toDateString());
+    }
+
+    public function test_regular_user_cannot_set_unlimited(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        // Non-admin sending unlimited=true should fall through to relative logic
+        // and use default 7-day relative extension (not set null)
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['unlimited' => true])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertNotNull($share->expires_at, 'Non-admin unlimited flag must be ignored');
+    }
+
+    public function test_regular_user_cannot_set_specific_date(): void
+    {
+        $owner  = $this->makeUser();
+        $share  = $this->makeShare($owner);
+        $target = Carbon::now()->addDays(90)->toDateString();
+
+        // Non-admin sending expires_at should fall through to relative logic
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['expires_at' => $target])
+            ->assertStatus(200);
+
+        $share->refresh();
+        // Should NOT be exactly 90 days from now (would be ~7 days from base)
+        $this->assertNotEquals($target, $share->expires_at->toDateString());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Input validation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_invalid_unit_is_rejected(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'years'])
+            ->assertStatus(422);
+    }
+
+    public function test_zero_amount_is_rejected(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 0, 'unit' => 'days'])
+            ->assertStatus(422);
+    }
+
+    public function test_negative_amount_is_rejected(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => -5, 'unit' => 'days'])
+            ->assertStatus(422);
+    }
+
+    public function test_nonexistent_share_returns_404(): void
+    {
+        $user = $this->makeUser();
+
+        $this->actingAs($user, 'sanctum')
+            ->postJson('/api/shares/999999/extend', ['amount' => 7, 'unit' => 'days'])
+            ->assertStatus(404);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Default behaviour (no payload — backward compat with old API)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_no_payload_defaults_to_7_day_relative_extension(): void
+    {
+        $owner = $this->makeUser();
+        $base  = Carbon::now()->addDays(10);
+        $share = $this->makeShare($owner, ['expires_at' => $base]);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), [])
+            ->assertStatus(200);
+
+        $share->refresh();
+        $expected = $base->copy()->addDays(7);
+
+        $this->assertEqualsWithDelta($expected->timestamp, $share->expires_at->timestamp, 60);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Response shape
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_success_response_includes_updated_share(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['amount' => 7, 'unit' => 'days']);
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'status',
+                'message',
+                'data' => ['share' => ['id', 'expires_at']],
+            ]);
+    }
+}

--- a/tests/Feature/ExtendShareTest.php
+++ b/tests/Feature/ExtendShareTest.php
@@ -304,20 +304,34 @@ class ExtendShareTest extends TestCase
         $this->assertNotNull($share->expires_at, 'Non-admin unlimited flag must be ignored');
     }
 
-    public function test_regular_user_cannot_set_specific_date(): void
+    public function test_regular_user_can_set_specific_date_within_max_expiry(): void
     {
+        $this->setMaxExpiry(30);
+
         $owner  = $this->makeUser();
         $share  = $this->makeShare($owner);
-        $target = Carbon::now()->addDays(90)->toDateString();
+        $target = Carbon::now()->addDays(20)->toDateString(); // within 30-day limit
 
-        // Non-admin sending expires_at should fall through to relative logic
         $this->actingAs($owner, 'sanctum')
             ->postJson($this->extendUrl($share->id), ['expires_at' => $target])
             ->assertStatus(200);
 
         $share->refresh();
-        // Should NOT be exactly 90 days from now (would be ~7 days from base)
-        $this->assertNotEquals($target, $share->expires_at->toDateString());
+        $this->assertEquals($target, $share->expires_at->toDateString());
+    }
+
+    public function test_regular_user_date_picker_rejects_date_beyond_max_expiry(): void
+    {
+        $this->setMaxExpiry(30);
+
+        $owner  = $this->makeUser();
+        $share  = $this->makeShare($owner);
+        $target = Carbon::now()->addDays(60)->toDateString(); // exceeds 30-day limit
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->extendUrl($share->id), ['expires_at' => $target])
+            ->assertStatus(422)
+            ->assertJsonPath('status', 'error');
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/tests/Feature/SharePendingDeletionTest.php
+++ b/tests/Feature/SharePendingDeletionTest.php
@@ -1,0 +1,308 @@
+<?php
+
+namespace Tests\Feature;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\Share;
+use Tests\TestCase;
+
+class SharePendingDeletionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private function makeUser(bool $admin = false): User
+    {
+        return User::factory()->create(['admin' => $admin]);
+    }
+
+    private function makeShare(User $owner, array $attrs = []): Share
+    {
+        return Share::create(array_merge([
+            'user_id'        => $owner->id,
+            'name'           => 'Test Share',
+            'description'    => '',
+            'path'           => 'test/' . $owner->id . '/' . uniqid(),
+            'long_id'        => 'share-' . uniqid(),
+            'size'           => 0,
+            'file_count'     => 0,
+            'download_limit' => null,
+            'download_count' => 0,
+            'require_email'  => false,
+            'expires_at'     => Carbon::now()->addDays(30),
+            'status'         => 'ready',
+        ], $attrs));
+    }
+
+    private function requestDeletionUrl(int $id): string
+    {
+        return "/api/shares/{$id}/request-deletion";
+    }
+
+    private function undoDeletionUrl(int $id): string
+    {
+        return "/api/shares/{$id}/undo-deletion";
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // requestDeletion — authentication
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_request_deletion_is_rejected(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $response = $this->postJson($this->requestDeletionUrl($share->id));
+
+        $this->assertNotEquals(200, $response->status());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // requestDeletion — authorisation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_owner_can_request_deletion_of_own_share(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id));
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'success');
+
+        $share->refresh();
+        $this->assertEquals('pending_deletion', $share->status);
+    }
+
+    public function test_admin_can_request_deletion_of_any_share(): void
+    {
+        $owner = $this->makeUser();
+        $admin = $this->makeUser(admin: true);
+        $share = $this->makeShare($owner);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id));
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'success');
+
+        $share->refresh();
+        $this->assertEquals('pending_deletion', $share->status);
+        $this->assertEquals('admin', $share->deletion_requested_by);
+    }
+
+    public function test_non_owner_cannot_request_deletion(): void
+    {
+        $owner = $this->makeUser();
+        $other = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $response = $this->actingAs($other, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id));
+
+        $response->assertStatus(401);
+
+        $share->refresh();
+        $this->assertEquals('ready', $share->status);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // requestDeletion — state recorded correctly
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_request_deletion_sets_deletion_requested_by_user(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id));
+
+        $share->refresh();
+        $this->assertEquals('user', $share->deletion_requested_by);
+        $this->assertNotNull($share->deletion_requested_at);
+    }
+
+    public function test_request_deletion_sets_deletion_requested_by_admin(): void
+    {
+        $owner = $this->makeUser();
+        $admin = $this->makeUser(admin: true);
+        $share = $this->makeShare($owner);
+
+        $this->actingAs($admin, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id));
+
+        $share->refresh();
+        $this->assertEquals('admin', $share->deletion_requested_by);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // requestDeletion — guard: already pending / deleted
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_cannot_double_request_deletion(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id));
+
+        $response->assertStatus(422);
+    }
+
+    public function test_cannot_request_deletion_of_already_deleted_share(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'deleted']);
+
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id));
+
+        $response->assertStatus(422);
+    }
+
+    public function test_cannot_request_deletion_of_nonexistent_share(): void
+    {
+        $user = $this->makeUser();
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/shares/999999/request-deletion');
+
+        $response->assertStatus(404);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // undoDeletion — authentication
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_unauthenticated_undo_deletion_is_rejected(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $response = $this->postJson($this->undoDeletionUrl($share->id));
+
+        $this->assertNotEquals(200, $response->status());
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // undoDeletion — authorisation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_owner_can_undo_deletion(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, [
+            'status'                 => 'pending_deletion',
+            'deletion_requested_at'  => Carbon::now(),
+            'deletion_requested_by'  => 'user',
+        ]);
+
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->undoDeletionUrl($share->id));
+
+        $response->assertStatus(200)
+            ->assertJsonPath('status', 'success');
+
+        $share->refresh();
+        $this->assertEquals('ready', $share->status);
+        $this->assertNull($share->deletion_requested_at);
+        $this->assertNull($share->deletion_requested_by);
+    }
+
+    public function test_admin_can_undo_deletion_of_any_share(): void
+    {
+        $owner = $this->makeUser();
+        $admin = $this->makeUser(admin: true);
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $response = $this->actingAs($admin, 'sanctum')
+            ->postJson($this->undoDeletionUrl($share->id));
+
+        $response->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals('ready', $share->status);
+    }
+
+    public function test_non_owner_cannot_undo_deletion(): void
+    {
+        $owner = $this->makeUser();
+        $other = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'pending_deletion']);
+
+        $response = $this->actingAs($other, 'sanctum')
+            ->postJson($this->undoDeletionUrl($share->id));
+
+        $response->assertStatus(401);
+
+        $share->refresh();
+        $this->assertEquals('pending_deletion', $share->status);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // undoDeletion — guard: not pending
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_cannot_undo_deletion_of_ready_share(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'ready']);
+
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->undoDeletionUrl($share->id));
+
+        $response->assertStatus(422);
+    }
+
+    public function test_cannot_undo_deletion_of_deleted_share(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner, ['status' => 'deleted']);
+
+        $response = $this->actingAs($owner, 'sanctum')
+            ->postJson($this->undoDeletionUrl($share->id));
+
+        $response->assertStatus(422);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Round-trip: request → undo → request again
+    // ──────────────────────────────────────────────────────────────────────────
+
+    public function test_round_trip_request_undo_rerequest(): void
+    {
+        $owner = $this->makeUser();
+        $share = $this->makeShare($owner);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id))
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals('pending_deletion', $share->status);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->undoDeletionUrl($share->id))
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals('ready', $share->status);
+
+        $this->actingAs($owner, 'sanctum')
+            ->postJson($this->requestDeletionUrl($share->id))
+            ->assertStatus(200);
+
+        $share->refresh();
+        $this->assertEquals('pending_deletion', $share->status);
+    }
+}

--- a/tests/scripts/test_admin_share_deletion.php
+++ b/tests/scripts/test_admin_share_deletion.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * Test harness for F5: Admin immediate share deletion.
+ *
+ * Tests:
+ * - deleteImmediately: admin-only, typed confirmation, valid target states
+ * - cleanExpiredShares job: processes pending_deletion alongside expired shares
+ * - Eligibility: which share states can be immediately deleted
+ *
+ * Does not require a running Laravel app or composer vendor/.
+ * Run with: php tests/scripts/test_admin_share_deletion.php
+ */
+
+$pass = 0;
+$fail = 0;
+$failures = [];
+
+function pass(string $name): void {
+    global $pass;
+    echo "PASS: $name\n";
+    $pass++;
+}
+
+function fail(string $name, string $detail = ''): void {
+    global $fail, $failures;
+    echo "FAIL: $name" . ($detail ? " — $detail" : '') . "\n";
+    $fail++;
+    $failures[] = $name;
+}
+
+function assert_eq(string $name, $expected, $actual): void {
+    if ($expected === $actual) {
+        pass($name);
+    } else {
+        fail($name, "expected " . var_export($expected, true) . ", got " . var_export($actual, true));
+    }
+}
+
+function assert_true(string $name, bool $value): void {
+    if ($value) pass($name);
+    else fail($name, "expected true");
+}
+
+function assert_false(string $name, bool $value): void {
+    if (!$value) pass($name);
+    else fail($name, "expected false");
+}
+
+// ---------------------------------------------------------------------------
+// Simulate share state objects
+// ---------------------------------------------------------------------------
+
+function makeShare(array $attrs = []): object {
+    return (object) array_merge([
+        'id'                    => 1,
+        'status'                => 'ready',
+        'expires_at'            => (new DateTime('+30 days'))->format('Y-m-d H:i:s'),
+        'deletion_requested_at' => null,
+        'deletion_requested_by' => null,
+        'cleaned'               => false,   // set to true by simulateCleanFiles()
+        'deleted_flag'          => false,
+    ], $attrs);
+}
+
+function makeAdmin(): object   { return (object)['id' => 1, 'admin' => true]; }
+function makeNonAdmin(): object { return (object)['id' => 2, 'admin' => false]; }
+
+// ---------------------------------------------------------------------------
+// Mirror: deleteImmediately() business logic
+// ---------------------------------------------------------------------------
+function deleteImmediately(object $share, object $user, ?string $confirmation): array {
+    if (!$user->admin) {
+        return ['status' => 'error', 'code' => 401, 'message' => 'Unauthorized'];
+    }
+
+    if (strtolower(trim($confirmation ?? '')) !== 'delete') {
+        return ['status' => 'error', 'code' => 422, 'message' => 'Confirmation required'];
+    }
+
+    if ($share->status === 'deleted') {
+        return ['status' => 'error', 'code' => 422, 'message' => 'Share is already deleted'];
+    }
+
+    $isExpired = $share->expires_at !== null && $share->expires_at < (new DateTime())->format('Y-m-d H:i:s');
+    $actionableStatuses = ['pending_deletion', 'deleted'];
+
+    if (!in_array($share->status, $actionableStatuses) && !$isExpired) {
+        return ['status' => 'error', 'code' => 422, 'message' => 'Share must be pending deletion or expired'];
+    }
+
+    // Simulate cleanFiles()
+    $share->cleaned = true;
+    $share->status  = 'deleted';
+
+    return ['status' => 'success', 'code' => 200, 'share' => $share];
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: canDeleteImmediately() Vue helper
+// ---------------------------------------------------------------------------
+function canDeleteImmediately(object $share): bool {
+    $isPending = $share->status === 'pending_deletion';
+    $isExpired = $share->expires_at !== null && $share->expires_at < (new DateTime())->format('Y-m-d H:i:s');
+    $isDeleted = $share->status === 'deleted';
+    return $isPending || ($isExpired && !$isDeleted);
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: cleanExpiredShares job — which shares get processed
+// ---------------------------------------------------------------------------
+function shouldCleanupJobProcess(object $share, int $cleanFilesAfterDays = 30): bool {
+    // Pending deletion: always processed
+    if ($share->status === 'pending_deletion') return true;
+
+    // Already deleted: skip
+    if ($share->status === 'deleted') return false;
+
+    // Expired past cleanup window
+    if ($share->expires_at !== null) {
+        $cleanAfter = (new DateTime($share->expires_at));
+        $cleanAfter->modify("+{$cleanFilesAfterDays} days");
+        return $cleanAfter < new DateTime();
+    }
+
+    return false;
+}
+
+// ===========================================================================
+// TEST CASES
+// ===========================================================================
+
+echo "=================================================================\n";
+echo "F5: Admin Immediate Share Deletion — Test Suite\n";
+echo "=================================================================\n\n";
+
+$admin    = makeAdmin();
+$nonAdmin = makeNonAdmin();
+
+// ---------------------------------------------------------------------------
+echo "-- Authorization: admin-only --\n\n";
+// ---------------------------------------------------------------------------
+
+$share = makeShare(['status' => 'pending_deletion']);
+$r = deleteImmediately($share, $nonAdmin, 'delete');
+assert_eq('Non-admin cannot call deleteImmediately', 'error', $r['status']);
+assert_eq('Non-admin gets 401', 401, $r['code']);
+assert_false('Non-admin attempt does not clean files', $share->cleaned);
+
+$share2 = makeShare(['status' => 'pending_deletion']);
+$r2 = deleteImmediately($share2, $admin, 'delete');
+assert_eq('Admin can call deleteImmediately', 'success', $r2['status']);
+assert_true('Admin attempt cleans files', $share2->cleaned);
+assert_eq('Share status set to deleted', 'deleted', $share2->status);
+
+// ---------------------------------------------------------------------------
+echo "\n-- Confirmation phrase --\n\n";
+// ---------------------------------------------------------------------------
+
+$share3 = makeShare(['status' => 'pending_deletion']);
+assert_eq('No confirmation → error', 'error', deleteImmediately($share3, $admin, null)['status']);
+assert_eq('Empty string → error', 'error', deleteImmediately($share3, $admin, '')['status']);
+assert_eq('Wrong word → error', 'error', deleteImmediately($share3, $admin, 'yes')['status']);
+assert_eq('Partial match → error', 'error', deleteImmediately($share3, $admin, 'delet')['status']);
+
+$share4 = makeShare(['status' => 'pending_deletion']);
+assert_eq('"delete" (lowercase) → success', 'success', deleteImmediately($share4, $admin, 'delete')['status']);
+
+$share5 = makeShare(['status' => 'pending_deletion']);
+assert_eq('"DELETE" (uppercase) → success (case-insensitive)', 'success', deleteImmediately($share5, $admin, 'DELETE')['status']);
+
+$share6 = makeShare(['status' => 'pending_deletion']);
+assert_eq('"  delete  " (whitespace) → success (trimmed)', 'success', deleteImmediately($share6, $admin, '  delete  ')['status']);
+
+// ---------------------------------------------------------------------------
+echo "\n-- Eligible share states --\n\n";
+// ---------------------------------------------------------------------------
+
+$pendingShare = makeShare(['status' => 'pending_deletion']);
+assert_eq('pending_deletion → can delete immediately', 'success', deleteImmediately($pendingShare, $admin, 'delete')['status']);
+
+$expiredShare = makeShare(['status' => 'ready', 'expires_at' => (new DateTime('-1 hour'))->format('Y-m-d H:i:s')]);
+assert_eq('expired ready share → can delete immediately', 'success', deleteImmediately($expiredShare, $admin, 'delete')['status']);
+
+$activeShare = makeShare(['status' => 'ready', 'expires_at' => (new DateTime('+30 days'))->format('Y-m-d H:i:s')]);
+$rActive = deleteImmediately($activeShare, $admin, 'delete');
+assert_eq('active (non-expired) share → cannot delete immediately', 'error', $rActive['status']);
+assert_eq('active share → 422', 422, $rActive['code']);
+
+$alreadyDeleted = makeShare(['status' => 'deleted']);
+$rDel = deleteImmediately($alreadyDeleted, $admin, 'delete');
+assert_eq('already-deleted share → error', 'error', $rDel['status']);
+assert_eq('already-deleted → 422', 422, $rDel['code']);
+
+// ---------------------------------------------------------------------------
+echo "\n-- canDeleteImmediately() Vue helper --\n\n";
+// ---------------------------------------------------------------------------
+
+assert_true('pending_deletion → button shown', canDeleteImmediately(makeShare(['status' => 'pending_deletion'])));
+assert_true('expired ready → button shown', canDeleteImmediately(makeShare([
+    'status' => 'ready',
+    'expires_at' => (new DateTime('-1 hour'))->format('Y-m-d H:i:s')
+])));
+assert_false('active share → button hidden', canDeleteImmediately(makeShare([
+    'status' => 'ready',
+    'expires_at' => (new DateTime('+30 days'))->format('Y-m-d H:i:s')
+])));
+assert_false('already deleted → button hidden', canDeleteImmediately(makeShare(['status' => 'deleted'])));
+
+// ---------------------------------------------------------------------------
+echo "\n-- cleanExpiredShares job: pending_deletion included --\n\n";
+// ---------------------------------------------------------------------------
+
+$pendingShare2 = makeShare(['status' => 'pending_deletion', 'expires_at' => (new DateTime('+30 days'))->format('Y-m-d H:i:s')]);
+assert_true('Job processes pending_deletion share even if not yet expired', shouldCleanupJobProcess($pendingShare2));
+
+$expiredOld = makeShare(['status' => 'ready', 'expires_at' => (new DateTime('-35 days'))->format('Y-m-d H:i:s')]);
+assert_true('Job processes share expired past cleanup window (30d)', shouldCleanupJobProcess($expiredOld));
+
+$expiredRecent = makeShare(['status' => 'ready', 'expires_at' => (new DateTime('-5 days'))->format('Y-m-d H:i:s')]);
+assert_false('Job skips share expired only recently (within 30d window)', shouldCleanupJobProcess($expiredRecent));
+
+$deletedShare2 = makeShare(['status' => 'deleted', 'expires_at' => (new DateTime('-60 days'))->format('Y-m-d H:i:s')]);
+assert_false('Job skips already-deleted shares', shouldCleanupJobProcess($deletedShare2));
+
+$activeShare2 = makeShare(['status' => 'ready', 'expires_at' => (new DateTime('+10 days'))->format('Y-m-d H:i:s')]);
+assert_false('Job skips active shares', shouldCleanupJobProcess($activeShare2));
+
+// ---------------------------------------------------------------------------
+echo "\n-- Idempotency: double-click guard --\n\n";
+// ---------------------------------------------------------------------------
+
+$share7 = makeShare(['status' => 'pending_deletion']);
+$r7a = deleteImmediately($share7, $admin, 'delete');
+assert_eq('First delete succeeds', 'success', $r7a['status']);
+$r7b = deleteImmediately($share7, $admin, 'delete');
+assert_eq('Second delete on same share fails (already deleted)', 'error', $r7b['status']);
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+echo "\n=================================================================\n";
+echo "Results: $pass passed, $fail failed\n";
+if ($fail > 0) {
+    echo "FAILURES:\n";
+    foreach ($failures as $f) {
+        echo "  - $f\n";
+    }
+    exit(1);
+}
+echo "All tests passed.\n";
+exit(0);

--- a/tests/scripts/test_share_pending_deletion.php
+++ b/tests/scripts/test_share_pending_deletion.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Test harness for F4: User-initiated share pending deletion.
+ *
+ * Tests the business logic of the pending_deletion state machine:
+ * - requestDeletion: valid transitions, auth, double-request guard
+ * - undoDeletion: valid revert, auth, non-pending guard
+ * - Email suppression: pending_deletion shares excluded from warning queries
+ * - Access control: read/download blocked for pending_deletion shares
+ *
+ * Does not require a running Laravel app or composer vendor/.
+ * Run with: php tests/scripts/test_share_pending_deletion.php
+ */
+
+$pass = 0;
+$fail = 0;
+$failures = [];
+
+function pass(string $name): void {
+    global $pass;
+    echo "PASS: $name\n";
+    $pass++;
+}
+
+function fail(string $name, string $detail = ''): void {
+    global $fail, $failures;
+    echo "FAIL: $name" . ($detail ? " — $detail" : '') . "\n";
+    $fail++;
+    $failures[] = $name;
+}
+
+function assert_eq(string $name, $expected, $actual): void {
+    if ($expected === $actual) {
+        pass($name);
+    } else {
+        fail($name, "expected " . var_export($expected, true) . ", got " . var_export($actual, true));
+    }
+}
+
+function assert_true(string $name, bool $value): void {
+    if ($value) pass($name);
+    else fail($name, "expected true");
+}
+
+function assert_false(string $name, bool $value): void {
+    if (!$value) pass($name);
+    else fail($name, "expected false");
+}
+
+// ---------------------------------------------------------------------------
+// Simulate share state objects (mirrors Share model attributes)
+// ---------------------------------------------------------------------------
+
+function makeShare(array $attrs = []): object {
+    return (object) array_merge([
+        'id' => 1,
+        'status' => 'ready',
+        'expires_at' => (new DateTime('+30 days'))->format('Y-m-d H:i:s'),
+        'deletion_requested_at' => null,
+        'deletion_requested_by' => null,
+    ], $attrs);
+}
+
+function makeUser(bool $admin = false): object {
+    return (object)['id' => 1, 'admin' => $admin];
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: Share::getPendingDeletionAttribute()
+// ---------------------------------------------------------------------------
+function isPendingDeletion(object $share): bool {
+    return $share->status === 'pending_deletion';
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: SharesController::canManageShare()
+// ---------------------------------------------------------------------------
+function canManageShare(object $share, object $user): bool {
+    if ($user->admin) return true;
+    if (isset($share->user_id) && $share->user_id === $user->id) return true;
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: SharesController::requestDeletion() business logic
+// ---------------------------------------------------------------------------
+function requestDeletion(object $share, object $user): array {
+    if (!canManageShare($share, $user)) {
+        return ['status' => 'error', 'code' => 401, 'message' => 'Unauthorized'];
+    }
+    if (in_array($share->status, ['pending_deletion', 'deleted'])) {
+        return ['status' => 'error', 'code' => 422, 'message' => 'Already pending deletion or deleted'];
+    }
+    $share->status = 'pending_deletion';
+    $share->deletion_requested_at = (new DateTime())->format('Y-m-d H:i:s');
+    $share->deletion_requested_by = $user->admin ? 'admin' : 'user';
+    return ['status' => 'success', 'code' => 200, 'share' => $share];
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: SharesController::undoDeletion() business logic
+// ---------------------------------------------------------------------------
+function undoDeletion(object $share, object $user): array {
+    if (!canManageShare($share, $user)) {
+        return ['status' => 'error', 'code' => 401, 'message' => 'Unauthorized'];
+    }
+    if ($share->status !== 'pending_deletion') {
+        return ['status' => 'error', 'code' => 422, 'message' => 'Share is not pending deletion'];
+    }
+    $share->status = 'ready';
+    $share->deletion_requested_at = null;
+    $share->deletion_requested_by = null;
+    return ['status' => 'success', 'code' => 200, 'share' => $share];
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: read() / download() access guard
+// ---------------------------------------------------------------------------
+function isAccessible(object $share): bool {
+    return !in_array($share->status, ['pending_deletion', 'deleted']);
+}
+
+// ---------------------------------------------------------------------------
+// Mirror: email job query filter (checks status exclusion)
+// ---------------------------------------------------------------------------
+function shouldReceiveExpiryWarning(object $share): bool {
+    // Mirrors: whereNotIn('status', ['pending_deletion', 'deleted'])
+    return !in_array($share->status, ['pending_deletion', 'deleted']);
+}
+
+// ===========================================================================
+// TEST CASES
+// ===========================================================================
+
+echo "=================================================================\n";
+echo "F4: Share Pending Deletion — Test Suite\n";
+echo "=================================================================\n\n";
+
+// ---------------------------------------------------------------------------
+echo "-- State machine: requestDeletion() --\n\n";
+// ---------------------------------------------------------------------------
+
+$owner = makeUser(false);
+$admin = makeUser(true);
+$other = (object)['id' => 99, 'admin' => false];
+
+$share = makeShare(['user_id' => 1, 'status' => 'ready']);
+$result = requestDeletion($share, $owner);
+assert_eq('Owner can request deletion of own share — status OK', 'success', $result['status']);
+assert_eq('Status set to pending_deletion', 'pending_deletion', $share->status);
+assert_eq('deletion_requested_by = user', 'user', $share->deletion_requested_by);
+assert_true('deletion_requested_at is set', $share->deletion_requested_at !== null);
+assert_true('share is now pending deletion', isPendingDeletion($share));
+
+$share2 = makeShare(['user_id' => 1, 'status' => 'ready']);
+$result2 = requestDeletion($share2, $admin);
+assert_eq('Admin can request deletion of any share', 'success', $result2['status']);
+assert_eq('deletion_requested_by = admin when admin requests', 'admin', $share2->deletion_requested_by);
+
+$share3 = makeShare(['user_id' => 1, 'status' => 'ready']);
+$result3 = requestDeletion($share3, $other);
+assert_eq('Non-owner cannot request deletion', 'error', $result3['status']);
+assert_eq('Non-owner gets 401', 401, $result3['code']);
+assert_eq('Share status unchanged after unauthorized request', 'ready', $share3->status);
+
+$shareAlready = makeShare(['user_id' => 1, 'status' => 'pending_deletion']);
+$result4 = requestDeletion($shareAlready, $owner);
+assert_eq('Cannot double-request deletion', 'error', $result4['status']);
+assert_eq('Double-request returns 422', 422, $result4['code']);
+
+$shareDeleted = makeShare(['user_id' => 1, 'status' => 'deleted']);
+$result5 = requestDeletion($shareDeleted, $owner);
+assert_eq('Cannot request deletion of already-deleted share', 'error', $result5['status']);
+assert_eq('Already-deleted returns 422', 422, $result5['code']);
+
+echo "\n-- State machine: undoDeletion() --\n\n";
+
+$sharePending = makeShare(['user_id' => 1, 'status' => 'pending_deletion',
+    'deletion_requested_at' => (new DateTime())->format('Y-m-d H:i:s'),
+    'deletion_requested_by' => 'user']);
+$undoResult = undoDeletion($sharePending, $owner);
+assert_eq('Owner can undo deletion of own share', 'success', $undoResult['status']);
+assert_eq('Status restored to ready', 'ready', $sharePending->status);
+assert_eq('deletion_requested_at cleared', null, $sharePending->deletion_requested_at);
+assert_eq('deletion_requested_by cleared', null, $sharePending->deletion_requested_by);
+assert_false('Share is no longer pending deletion', isPendingDeletion($sharePending));
+
+$sharePending2 = makeShare(['user_id' => 1, 'status' => 'pending_deletion',
+    'deletion_requested_at' => (new DateTime())->format('Y-m-d H:i:s'),
+    'deletion_requested_by' => 'user']);
+$undoAdmin = undoDeletion($sharePending2, $admin);
+assert_eq('Admin can undo deletion on any share', 'success', $undoAdmin['status']);
+
+$shareReady = makeShare(['user_id' => 1, 'status' => 'ready']);
+$undoBad = undoDeletion($shareReady, $owner);
+assert_eq('Cannot undo deletion of non-pending share', 'error', $undoBad['status']);
+assert_eq('Non-pending undo returns 422', 422, $undoBad['code']);
+
+$shareReady2 = makeShare(['user_id' => 1, 'status' => 'ready']);
+$undoOther = undoDeletion($shareReady2, $other);
+assert_eq('Non-owner cannot undo deletion', 'error', $undoOther['status']);
+assert_eq('Non-owner undo returns 401', 401, $undoOther['code']);
+
+echo "\n-- Access control: read() / download() --\n\n";
+
+$activeShare = makeShare(['status' => 'ready']);
+assert_true('Active share is accessible', isAccessible($activeShare));
+
+$pendingShare = makeShare(['status' => 'pending_deletion']);
+assert_false('Pending deletion share is not accessible', isAccessible($pendingShare));
+
+$deletedShare = makeShare(['status' => 'deleted']);
+assert_false('Deleted share is not accessible', isAccessible($deletedShare));
+
+$expiredShare = makeShare(['status' => 'ready', 'expires_at' => (new DateTime('-1 hour'))->format('Y-m-d H:i:s')]);
+assert_true('Expired-but-ready share passes the pending_deletion gate (expiry checked separately)', isAccessible($expiredShare));
+
+echo "\n-- Email suppression: warning emails skip pending_deletion --\n\n";
+
+$readyShare    = makeShare(['status' => 'ready']);
+$pendingShare2 = makeShare(['status' => 'pending_deletion']);
+$deletedShare2 = makeShare(['status' => 'deleted']);
+
+assert_true('Ready share receives expiry warning', shouldReceiveExpiryWarning($readyShare));
+assert_false('Pending deletion share suppressed from expiry warning', shouldReceiveExpiryWarning($pendingShare2));
+assert_false('Deleted share suppressed from expiry warning', shouldReceiveExpiryWarning($deletedShare2));
+
+echo "\n-- Round-trip: request then undo then re-request --\n\n";
+
+$shareRT = makeShare(['user_id' => 1, 'status' => 'ready']);
+$r1 = requestDeletion($shareRT, $owner);
+assert_eq('Round-trip step 1: request deletion succeeds', 'success', $r1['status']);
+$u1 = undoDeletion($shareRT, $owner);
+assert_eq('Round-trip step 2: undo succeeds', 'success', $u1['status']);
+assert_eq('Round-trip step 2: status back to ready', 'ready', $shareRT->status);
+$r2 = requestDeletion($shareRT, $owner);
+assert_eq('Round-trip step 3: can request deletion again after undo', 'success', $r2['status']);
+assert_eq('Round-trip step 3: status is pending_deletion again', 'pending_deletion', $shareRT->status);
+
+// ---------------------------------------------------------------------------
+// Negative tests
+// ---------------------------------------------------------------------------
+echo "\n-- Negative tests --\n\n";
+
+$shareNull = makeShare(['user_id' => 1, 'status' => 'pending']);
+$negResult = requestDeletion($shareNull, $owner);
+assert_eq('Pending (zip building) share can be requested for deletion', 'success', $negResult['status']);
+
+$shareFailed = makeShare(['user_id' => 1, 'status' => 'failed']);
+$negResult2 = requestDeletion($shareFailed, $owner);
+assert_eq('Failed share can be requested for deletion', 'success', $negResult2['status']);
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+echo "\n=================================================================\n";
+echo "Results: $pass passed, $fail failed\n";
+if ($fail > 0) {
+    echo "FAILURES:\n";
+    foreach ($failures as $f) {
+        echo "  - $f\n";
+    }
+    exit(1);
+}
+echo "All tests passed.\n";
+exit(0);


### PR DESCRIPTION
Introduces end-to-end lifecycle controls for shares. All temporal and
deletion actions are consolidated into a split-button dropdown off the
Expire Now button for a clean, discoverable UX.

## Extend expiration

Users can extend a share's expiry date at any time via a date picker in a
dedicated modal. The new date is bounded by the system max_expiry_time
setting. Admins can set any future date or clear the expiry entirely
(unlimited retention).

New component: ExtendShareModal.vue
New endpoint: POST /api/shares/{id}/extend

## Pending deletion (user-initiated)

Users can request early deletion of a share before its natural expiry. The
share enters a pending_deletion status immediately — the download link stops
working — but files are not removed until the cleanup job runs. The request
can be cancelled at any time before cleanup with an Undo action.

Expired shares (past their expiry date) are shown in a separate section in
My Shares with an amber notice banner, distinct from active shares.

New migration: adds deletion_requested_at (timestamp) and
deletion_requested_by ('user'|'admin') columns to the shares table.
New endpoint: POST /api/shares/{id}/request-deletion
New endpoint: POST /api/shares/{id}/undo-deletion

cleanExpiredShares job updated to also process shares with
status = pending_deletion, in addition to shares past their expiry window.

## Admin immediate deletion

Admins can bypass the pending period and remove a share's files immediately
from the All Shares view. The action requires typing DELETE in a confirmation
dialog to prevent accidental removal.

New endpoint: POST /api/shares/{id}/delete-immediately (admin only)

## Permanent record removal (purge)

Once a share has been cleaned (status deleted), the owner or an admin can
permanently remove the database record. This completes the lifecycle and
removes the entry from the shares list.

New endpoint: DELETE /api/shares/{id}

## UX

All four actions are surfaced through a split-button dropdown in My Shares
and All Shares. Expire Now remains the primary button; Extend / Request
Deletion / Undo Deletion / Remove Entry appear as contextual secondary
actions, shown only when applicable to the share's current state. The
dropdown closes on click-outside.

## i18n

All six locales updated (en, de, fr, it, nl, pt).

## Tests

- tests/Feature/SharePendingDeletionTest.php (308 lines)
- tests/Feature/AdminShareDeletionTest.php (269 lines)
- tests/Feature/ExtendShareTest.php


**A complete, ready-to-run container with these features built, is available for preview and testing here:**
~ghcr.io/rza-sf/erugo:0.2.15-2394df9~

**Update (2026-07-28): Incl. fix for https://github.com/ErugoOSS/Erugo/pull/265 
ghcr.io/rza-sf/erugo:0.2.15-421a556**

// RZA-SF //