### PR TITLE
feat: admin diagnostics bundle with AES-256 encrypted ZIP download

### DIFF
--- a/app/Http/Controllers/DiagnosticsController.php
+++ b/app/Http/Controllers/DiagnosticsController.php
@@ -1,0 +1,398 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Share;
+use App\Models\User;
+use App\Models\File;
+use App\Models\Setting;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Carbon\Carbon;
+use ZipArchive;
+
+class DiagnosticsController extends Controller
+{
+    /** Keys whose values must be redacted from the settings dump. */
+    private const SENSITIVE_SETTING_KEYS = [
+        'smtp_password', 'smtp_user', 'smtp_host', 'mail_password',
+        'oauth_client_secret', 'oauth_secret', 'api_key', 'secret',
+    ];
+
+    /**
+     * Generate a diagnostic bundle, cache it under a one-time token,
+     * and return the token + decryption key so the frontend can trigger
+     * the download separately.
+     */
+    public function generate()
+    {
+        $user = Auth::user();
+        if (!$user || !$user->admin) {
+            return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+        }
+
+        // Random ZIP password shown once to the admin
+        $password = strtoupper(Str::random(6)) . '-' .
+                    strtolower(Str::random(6)) . '-' .
+                    strtoupper(Str::random(6));
+
+        $filename = 'erugo-diagnostics-' . now()->format('Y-m-d-His') . '.zip';
+        $tmpPath  = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $filename;
+
+        try {
+            $files = $this->collectDiagnostics();
+            $this->buildEncryptedZip($files, $tmpPath, $password);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'status'  => 'error',
+                'message' => 'Failed to generate diagnostic bundle: ' . $e->getMessage(),
+            ], 500);
+        }
+
+        // One-time download token, valid 15 minutes
+        $token = Str::random(48);
+        Cache::put('diag_' . $token, ['path' => $tmpPath, 'filename' => $filename], now()->addMinutes(15));
+
+        return response()->json([
+            'status' => 'success',
+            'data'   => [
+                'token'    => $token,
+                'key'      => $password,
+                'filename' => $filename,
+            ],
+        ]);
+    }
+
+    /**
+     * Stream the cached diagnostic bundle to the browser (one-time).
+     */
+    public function download(string $token)
+    {
+        $user = Auth::user();
+        if (!$user || !$user->admin) {
+            return response()->json(['status' => 'error', 'message' => 'Unauthorized'], 401);
+        }
+
+        $bundle = Cache::get('diag_' . $token);
+        if (!$bundle || !file_exists($bundle['path'])) {
+            return response()->json(['status' => 'error', 'message' => 'Bundle not found or expired'], 404);
+        }
+
+        Cache::forget('diag_' . $token);
+
+        return response()->download($bundle['path'], $bundle['filename'], [
+            'Content-Type'        => 'application/zip',
+            'Content-Disposition' => 'attachment; filename="' . $bundle['filename'] . '"',
+        ])->deleteFileAfterSend(true);
+    }
+
+    // -------------------------------------------------------------------------
+    // Data collection
+    // -------------------------------------------------------------------------
+
+    private function collectDiagnostics(): array
+    {
+        $files = [];
+
+        $files['README.txt']      = $this->buildReadme();
+        $files['system.json']     = $this->systemInfo();
+        $files['environment.json']= $this->environmentInfo();
+        $files['database.json']   = $this->databaseInfo();
+        $files['shares.json']     = $this->sharesInfo();
+        $files['users.json']      = $this->usersInfo();
+        $files['settings.json']   = $this->settingsInfo();
+        $files['storage.json']    = $this->storageInfo();
+        $files['queue.json']      = $this->queueInfo();
+        $files['logs/laravel.log']= $this->laravelLog();
+
+        return $files;
+    }
+
+    private function buildReadme(): string
+    {
+        return <<<TXT
+Erugo Diagnostic Bundle
+=======================
+Generated : {$this->now()}
+App       : {$this->appVersion()}
+
+This ZIP archive is password-protected with AES-256.
+The decryption code was displayed once in the Erugo admin UI at the time
+this bundle was generated.  Keep it secure.
+
+Contents
+--------
+  README.txt        — this file
+  system.json       — PHP, OS, memory, disk capacity
+  environment.json  — sanitised runtime environment variables
+  database.json     — DB engine, connection info, record counts
+  shares.json       — per-share summary (no file paths or passwords)
+  users.json        — user list (no password hashes)
+  settings.json     — application settings (sensitive values redacted)
+  storage.json      — storage directory tree and sizes
+  queue.json        — queue driver and pending job count
+  logs/laravel.log  — last 1 000 lines of the Laravel application log
+
+TXT;
+    }
+
+    private function systemInfo(): string
+    {
+        $uptime = '';
+        if (is_readable('/proc/uptime')) {
+            $secs   = (int) explode(' ', file_get_contents('/proc/uptime'))[0];
+            $uptime = sprintf('%dd %dh %dm', intdiv($secs, 86400), intdiv($secs % 86400, 3600), intdiv($secs % 3600, 60));
+        }
+
+        return json_encode([
+            'erugo_version'  => $this->appVersion(),
+            'php_version'    => phpversion(),
+            'php_extensions' => get_loaded_extensions(),
+            'laravel_version'=> app()->version(),
+            'os'             => php_uname(),
+            'server_software'=> $_SERVER['SERVER_SOFTWARE'] ?? 'unknown',
+            'uptime'         => $uptime ?: 'unavailable',
+            'memory_limit'   => ini_get('memory_limit'),
+            'max_exec_time'  => ini_get('max_execution_time'),
+            'generated_at'   => $this->now(),
+        ], JSON_PRETTY_PRINT);
+    }
+
+    private function environmentInfo(): string
+    {
+        $redactPatterns = ['PASSWORD', 'SECRET', 'KEY', 'TOKEN', 'PRIVATE', 'CREDENTIAL'];
+        $safe = [];
+        foreach ($_ENV + getenv() as $k => $v) {
+            $upper = strtoupper($k);
+            $redact = false;
+            foreach ($redactPatterns as $pat) {
+                if (str_contains($upper, $pat)) { $redact = true; break; }
+            }
+            $safe[$k] = $redact ? '*** REDACTED ***' : $v;
+        }
+        ksort($safe);
+
+        return json_encode(['environment' => $safe, 'generated_at' => $this->now()], JSON_PRETTY_PRINT);
+    }
+
+    private function databaseInfo(): string
+    {
+        $conn    = config('database.default');
+        $driver  = config("database.connections.{$conn}.driver", 'unknown');
+        $dbName  = config("database.connections.{$conn}.database", 'unknown');
+
+        $dbSize = null;
+        if ($driver === 'sqlite' && file_exists($dbName)) {
+            $dbSize = filesize($dbName);
+        }
+
+        return json_encode([
+            'connection'   => $conn,
+            'driver'       => $driver,
+            'database'     => basename((string) $dbName),
+            'database_size_bytes' => $dbSize,
+            'counts' => [
+                'users'    => User::count(),
+                'shares'   => Share::count(),
+                'files'    => File::count(),
+                'settings' => Setting::count(),
+            ],
+            'share_status_breakdown' => Share::select('status', DB::raw('count(*) as count'))
+                ->groupBy('status')->pluck('count', 'status'),
+            'generated_at' => $this->now(),
+        ], JSON_PRETTY_PRINT);
+    }
+
+    private function sharesInfo(): string
+    {
+        $shares = Share::with('user:id,name,email')
+            ->select('id', 'name', 'user_id', 'status', 'file_count', 'size',
+                     'created_at', 'updated_at', 'expires_at', 'invite_id',
+                     'deletion_requested_at', 'deletion_requested_by')
+            ->orderByDesc('created_at')
+            ->get()
+            ->map(fn($s) => [
+                'id'           => $s->id,
+                'name'         => $s->name,
+                'owner'        => $s->user ? $s->user->email : null,
+                'status'       => $s->status,
+                'file_count'   => $s->file_count,
+                'size_bytes'   => $s->size,
+                'created_at'   => $s->created_at,
+                'expires_at'   => $s->expires_at,
+                'updated_at'   => $s->updated_at,
+                'pending_deletion' => $s->deletion_requested_at ? [
+                    'requested_at' => $s->deletion_requested_at,
+                    'requested_by' => $s->deletion_requested_by,
+                ] : null,
+            ]);
+
+        return json_encode([
+            'total'        => $shares->count(),
+            'shares'       => $shares,
+            'generated_at' => $this->now(),
+        ], JSON_PRETTY_PRINT);
+    }
+
+    private function usersInfo(): string
+    {
+        $users = User::select('id', 'name', 'email', 'admin', 'created_at', 'updated_at')
+            ->withCount('shares')
+            ->orderBy('id')
+            ->get();
+
+        return json_encode([
+            'total'        => $users->count(),
+            'users'        => $users,
+            'generated_at' => $this->now(),
+        ], JSON_PRETTY_PRINT);
+    }
+
+    private function settingsInfo(): string
+    {
+        $settings = Setting::all()->mapWithKeys(function ($s) {
+            $redact = false;
+            foreach (self::SENSITIVE_SETTING_KEYS as $pat) {
+                if (str_contains(strtolower($s->key), $pat)) { $redact = true; break; }
+            }
+            return [$s->key => $redact ? '*** REDACTED ***' : $s->value];
+        });
+
+        return json_encode([
+            'settings'     => $settings,
+            'generated_at' => $this->now(),
+        ], JSON_PRETTY_PRINT);
+    }
+
+    private function storageInfo(): string
+    {
+        $base    = storage_path('app');
+        $info    = ['base_path' => $base, 'generated_at' => $this->now(), 'directories' => []];
+
+        foreach (['shares', 'uploads', 'public', 'private'] as $dir) {
+            $path = $base . DIRECTORY_SEPARATOR . $dir;
+            if (is_dir($path)) {
+                $info['directories'][$dir] = [
+                    'path'        => $path,
+                    'size_bytes'  => $this->dirSize($path),
+                    'file_count'  => $this->dirFileCount($path),
+                ];
+            }
+        }
+
+        $info['disk'] = [
+            'total_bytes' => disk_total_space($base),
+            'free_bytes'  => disk_free_space($base),
+            'used_bytes'  => disk_total_space($base) - disk_free_space($base),
+        ];
+
+        return json_encode($info, JSON_PRETTY_PRINT);
+    }
+
+    private function queueInfo(): string
+    {
+        $driver = config('queue.default', 'sync');
+        $pending = null;
+        try {
+            $pending = DB::table('jobs')->count();
+        } catch (\Throwable) {}
+
+        return json_encode([
+            'driver'        => $driver,
+            'pending_jobs'  => $pending,
+            'generated_at'  => $this->now(),
+        ], JSON_PRETTY_PRINT);
+    }
+
+    private function laravelLog(): string
+    {
+        $logPath = storage_path('logs/laravel.log');
+        if (!file_exists($logPath)) {
+            return "Log file not found: {$logPath}\n";
+        }
+
+        // Read last 1 000 lines efficiently
+        $lines = [];
+        $fp    = fopen($logPath, 'r');
+        fseek($fp, 0, SEEK_END);
+        $pos    = ftell($fp);
+        $buffer = '';
+        $count  = 0;
+
+        while ($pos > 0 && $count < 1000) {
+            $chunk   = min($pos, 8192);
+            $pos    -= $chunk;
+            fseek($fp, $pos);
+            $buffer  = fread($fp, $chunk) . $buffer;
+            $count   = substr_count($buffer, "\n");
+        }
+        fclose($fp);
+
+        $all = explode("\n", $buffer);
+        return implode("\n", array_slice($all, -1000));
+    }
+
+    // -------------------------------------------------------------------------
+    // ZIP builder
+    // -------------------------------------------------------------------------
+
+    private function buildEncryptedZip(array $files, string $dest, string $password): void
+    {
+        $zip = new ZipArchive();
+        $result = $zip->open($dest, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        if ($result !== true) {
+            throw new \RuntimeException("ZipArchive::open failed with code {$result}");
+        }
+
+        $zip->setPassword($password);
+
+        foreach ($files as $name => $content) {
+            // Ensure subdirectories exist inside the archive
+            $dir = dirname($name);
+            if ($dir !== '.') {
+                $zip->addEmptyDir($dir);
+            }
+            $zip->addFromString($name, $content);
+            $zip->setEncryptionName($name, ZipArchive::EM_AES_256);
+        }
+
+        if (!$zip->close()) {
+            throw new \RuntimeException('ZipArchive::close failed — archive may be incomplete');
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private function dirSize(string $path): int
+    {
+        $size = 0;
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)) as $file) {
+            $size += $file->getSize();
+        }
+        return $size;
+    }
+
+    private function dirFileCount(string $path): int
+    {
+        $count = 0;
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS)) as $file) {
+            if ($file->isFile()) $count++;
+        }
+        return $count;
+    }
+
+    private function appVersion(): string
+    {
+        return env('APP_VERSION', config('app.version', 'unknown'));
+    }
+
+    private function now(): string
+    {
+        return Carbon::now()->toIso8601String();
+    }
+}

--- a/resources/js/api.js
+++ b/resources/js/api.js
@@ -1721,3 +1721,32 @@ export const uploadFilesInChunks = async (
     }
   }
 }
+
+export const generateDiagnosticsBundle = async () => {
+  const response = await fetchWithAuth(`${apiUrl}/api/admin/diagnostics`, {
+    method: 'POST',
+    headers: { ...addJsonHeader() },
+  })
+  const data = await response.json()
+  if (!response.ok) throw new Error(data.message || 'Failed to generate diagnostics bundle')
+  return data.data  // { token, key, filename }
+}
+
+export const downloadDiagnosticsBundle = async (token, filename) => {
+  const response = await fetchWithAuth(`${apiUrl}/api/admin/diagnostics/${token}`, {
+    method: 'GET',
+  })
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
+    throw new Error(data.message || 'Failed to download diagnostics bundle')
+  }
+  const blob = await response.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}

--- a/resources/js/components/DiagnosticsModal.vue
+++ b/resources/js/components/DiagnosticsModal.vue
@@ -1,0 +1,223 @@
+<script setup>
+import { ref } from 'vue'
+import { ShieldCheck, Copy, Check, TriangleAlert, X } from 'lucide-vue-next'
+
+const props = defineProps({
+  decryptionKey: { type: String, required: true },
+  filename:      { type: String, required: true },
+})
+const emit = defineEmits(['close'])
+
+const copied = ref(false)
+
+const copyKey = async () => {
+  try {
+    await navigator.clipboard.writeText(props.decryptionKey)
+    copied.value = true
+    setTimeout(() => { copied.value = false }, 3000)
+  } catch {
+    // fallback: select the text
+    const el = document.getElementById('diag-key-text')
+    if (el) { el.select(); document.execCommand('copy') }
+  }
+}
+</script>
+
+<template>
+  <div class="modal-backdrop" @click.self="emit('close')">
+    <div class="modal-box">
+
+      <div class="modal-header">
+        <ShieldCheck class="header-icon" />
+        <h3>Diagnostics Bundle Ready</h3>
+        <button class="close-btn" @click="emit('close')"><X /></button>
+      </div>
+
+      <p class="intro">
+        The encrypted diagnostics bundle <strong>{{ filename }}</strong> is
+        downloading in the background.  You need the decryption code below to
+        open it.
+      </p>
+
+      <div class="key-area">
+        <label class="key-label">Decryption code</label>
+        <div class="key-row">
+          <input
+            id="diag-key-text"
+            class="key-input"
+            type="text"
+            :value="decryptionKey"
+            readonly
+          />
+          <button class="copy-btn" @click="copyKey" :class="{ copied }">
+            <Check v-if="copied" />
+            <Copy v-else />
+            {{ copied ? 'Copied!' : 'Copy' }}
+          </button>
+        </div>
+      </div>
+
+      <div class="warning-box">
+        <TriangleAlert />
+        <div>
+          <strong>Save this code now — it will not be shown again.</strong>
+          <p>
+            The ZIP is encrypted with AES-256.  Enter this code when opening the
+            archive in any standard ZIP application (7-Zip, macOS Archive Utility,
+            Windows Explorer, etc.).
+          </p>
+        </div>
+      </div>
+
+      <div class="modal-footer">
+        <button @click="emit('close')">Done</button>
+      </div>
+
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-box {
+  background: var(--panel-section-background-color);
+  border-radius: 10px;
+  padding: 24px;
+  min-width: 380px;
+  max-width: 540px;
+  width: 100%;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+
+  .header-icon { width: 1.3rem; height: 1.3rem; color: #10b981; flex-shrink: 0; }
+  h3 { flex: 1; margin: 0; font-size: 1.1rem; color: var(--panel-section-text-color); }
+
+  .close-btn {
+    background: none; border: none; padding: 4px; cursor: pointer;
+    display: flex; align-items: center; color: var(--panel-section-text-color); opacity: 0.6;
+    &:hover { opacity: 1; }
+    svg { width: 1rem; height: 1rem; }
+    margin-right: 0 !important;
+  }
+}
+
+.intro {
+  font-size: 0.88rem;
+  color: var(--panel-section-text-color);
+  opacity: 0.85;
+  margin: 0 0 18px;
+  line-height: 1.5;
+}
+
+.key-area {
+  margin-bottom: 18px;
+
+  .key-label {
+    display: block;
+    font-size: 0.8rem;
+    color: var(--panel-section-text-color);
+    opacity: 0.65;
+    margin-bottom: 6px;
+  }
+
+  .key-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+  }
+
+  .key-input {
+    flex: 1;
+    font-family: monospace;
+    font-size: 1rem;
+    letter-spacing: 0.05em;
+    padding: 10px 12px;
+    border-radius: 6px;
+    border: 1px solid rgba(128, 128, 128, 0.3);
+    background: var(--panel-section-background-color-alt);
+    color: var(--panel-section-text-color);
+    box-sizing: border-box;
+    cursor: text;
+    // Override global input styles
+    width: auto;
+    height: auto;
+    margin-bottom: 0;
+    &:focus { outline: 2px solid var(--primary-color, #4f6ef7); border-color: transparent; }
+  }
+
+  .copy-btn {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 14px;
+    border-radius: 6px;
+    border: none;
+    font-size: 0.88rem;
+    cursor: pointer;
+    white-space: nowrap;
+    background: var(--primary-color, #4f6ef7);
+    color: #fff;
+    transition: background 0.15s, opacity 0.15s;
+    margin-right: 0 !important;
+
+    &.copied { background: #10b981; }
+    &:hover { opacity: 0.9; }
+
+    svg { width: 0.9rem; height: 0.9rem; }
+  }
+}
+
+.warning-box {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.4);
+  border-radius: 8px;
+  padding: 14px;
+  margin-bottom: 20px;
+
+  svg {
+    width: 1.1rem;
+    height: 1.1rem;
+    color: #f59e0b;
+    flex-shrink: 0;
+    margin-top: 2px;
+  }
+
+  strong {
+    display: block;
+    font-size: 0.88rem;
+    color: var(--panel-section-text-color);
+    margin-bottom: 4px;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--panel-section-text-color);
+    opacity: 0.8;
+    line-height: 1.5;
+  }
+}
+
+.modal-footer {
+  display: flex;
+  justify-content: flex-end;
+}
+</style>

--- a/resources/js/components/settings.vue
+++ b/resources/js/components/settings.vue
@@ -19,7 +19,8 @@ import {
   RefreshCw,
   Loader2,
   LogIn,
-  Info
+  Info,
+  PackageSearch
 } from 'lucide-vue-next'
 import { ref, onMounted } from 'vue'
 import Users from './settings/users.vue'
@@ -31,7 +32,8 @@ import MyProfile from './settings/myProfile.vue'
 import MyShares from './settings/myShares.vue'
 import AllShares from './settings/allShares.vue'
 import About from './settings/about.vue'
-import { getUsers } from '../api'
+import DiagnosticsModal from './DiagnosticsModal.vue'
+import { getUsers, generateDiagnosticsBundle, downloadDiagnosticsBundle } from '../api'
 import ButtonWithMenu from './buttonWithMenu.vue'
 import { useSetting } from '../composables/useSetting'
 import { useSettingsNavigation, updateUrlHash, buildSettingsPath, clearUrlHash } from '../composables/useSettingsNavigation'
@@ -106,6 +108,28 @@ const setActiveTab = (tab, options = {}) => {
 
 const getInitialTab = () => {
   return 'myShares'
+}
+
+// Diagnostics bundle
+const diagnosticsGenerating = ref(false)
+const diagnosticsKey = ref(null)
+const diagnosticsFilename = ref(null)
+
+const handleDownloadDiagnostics = async () => {
+  if (!confirm(t.value('settings.diagnostics.confirm') || 'Collect and download a diagnostic bundle? This may take a few seconds.')) return
+  diagnosticsGenerating.value = true
+  try {
+    const { token, key, filename } = await generateDiagnosticsBundle()
+    diagnosticsKey.value = key
+    diagnosticsFilename.value = filename
+    // Trigger download in background before showing the modal
+    await downloadDiagnosticsBundle(token, filename)
+  } catch (e) {
+    alert(e.message || 'Failed to generate diagnostics bundle')
+    diagnosticsKey.value = null
+  } finally {
+    diagnosticsGenerating.value = false
+  }
 }
 
 // Track active tab
@@ -243,6 +267,11 @@ const handleUserFilterChange = (event) => {
         </h1>
         <button class="settings-help-button icon-only" @click="goToHelp">
           <HelpCircle />
+        </button>
+        <button v-if="store.isAdmin()" class="secondary" @click="handleDownloadDiagnostics" :disabled="diagnosticsGenerating">
+          <Loader2 v-if="diagnosticsGenerating" class="spinner" />
+          <PackageSearch v-else />
+          {{ diagnosticsGenerating ? ($t('settings.diagnostics.generating') || 'Collecting…') : ($t('settings.diagnostics.button') || 'Diagnostics') }}
         </button>
         <button class="close-settings-button icon-only" @click="closeSettings">
           <CircleX />
@@ -597,6 +626,13 @@ const handleUserFilterChange = (event) => {
       </div>
     </div>
   </div>
+
+  <DiagnosticsModal
+    v-if="diagnosticsKey"
+    :decryption-key="diagnosticsKey"
+    :filename="diagnosticsFilename"
+    @close="diagnosticsKey = null"
+  />
 </template>
 
 <style lang="scss" scoped>

--- a/resources/js/i18n/de.json
+++ b/resources/js/i18n/de.json
@@ -598,6 +598,11 @@
       "password_protect_description": "Erstellen Sie ein Passwort für Ihre Freigabe. Jeder, der diese Freigabe herunterlädt, benötigt dieses Passwort, um darauf zuzugreifen. Bitte beachten Sie: Nach der Erstellung wird dieses Kennwort verschlüsselt und wir können es nicht für Sie abrufen. Speichern Sie es daher an einem sicheren Ort.",
       "remove_password": "Passwort entfernen"
     },
+    "diagnostics": {
+      "button": "Diagnostics",
+      "generating": "Collecting…",
+      "confirm": "Collect and download a diagnostic bundle? This may take a few seconds."
+    },
     "stats": {
       "downloads": {
         "all_time": "All-Time Downloads",

--- a/resources/js/i18n/en.json
+++ b/resources/js/i18n/en.json
@@ -619,6 +619,11 @@
       "password_protect_description": "Create a password for your share. Anyone downloading this share will need this password to access it. Please note: After creation, this password will be encrypted and we cannot retrieve it for you. Make sure to save it in a secure location.",
       "remove_password": "Remove Password"
     },
+    "diagnostics": {
+      "button": "Diagnostics",
+      "generating": "Collecting…",
+      "confirm": "Collect and download a diagnostic bundle? This may take a few seconds."
+    },
     "stats": {
       "downloads": {
         "all_time": "All-Time Downloads",

--- a/resources/js/i18n/fr.json
+++ b/resources/js/i18n/fr.json
@@ -598,6 +598,11 @@
       "password_protect_description": "Créez un mot de passe pour votre partage. Toute personne téléchargeant ce partage aura besoin de ce mot de passe pour y accéder. Remarque : après sa création, ce mot de passe sera crypté et nous ne pourrons pas le récupérer pour vous. Veillez à le sauvegarder dans un endroit sûr.",
       "remove_password": "Supprimer le mot de passe"
     },
+    "diagnostics": {
+      "button": "Diagnostics",
+      "generating": "Collecting…",
+      "confirm": "Collect and download a diagnostic bundle? This may take a few seconds."
+    },
     "stats": {
       "downloads": {
         "all_time": "Nombre total de téléchargement(s)",

--- a/resources/js/i18n/it.json
+++ b/resources/js/i18n/it.json
@@ -598,6 +598,11 @@
       "password_protect_description": "Crea una password per la tua condivisione. Chiunque scarichi questa condivisione avrà bisogno di questa password per accedervi. Nota bene: dopo la creazione, la password sarà crittografata e non sarà possibile recuperarla. Assicurati di salvarla in un luogo sicuro.",
       "remove_password": "Rimuovi la password"
     },
+    "diagnostics": {
+      "button": "Diagnostics",
+      "generating": "Collecting…",
+      "confirm": "Collect and download a diagnostic bundle? This may take a few seconds."
+    },
     "stats": {
       "downloads": {
         "all_time": "Download di sempre",

--- a/resources/js/i18n/nl.json
+++ b/resources/js/i18n/nl.json
@@ -598,6 +598,11 @@
       "password_protect_description": "Maak een wachtwoord aan voor je gedeelde link. Iedereen die dit bestand downloadt, heeft dit wachtwoord nodig om toegang te krijgen. Let op: Na het aanmaken wordt dit wachtwoord versleuteld en kunnen we het niet voor je achterhalen. Zorg ervoor dat je het op een veilige locatie opslaat.",
       "remove_password": "Wachtwoord verwijderen"
     },
+    "diagnostics": {
+      "button": "Diagnostics",
+      "generating": "Collecting…",
+      "confirm": "Collect and download a diagnostic bundle? This may take a few seconds."
+    },
     "stats": {
       "downloads": {
         "all_time": "Downloads aller tijden",

--- a/resources/js/i18n/pt.json
+++ b/resources/js/i18n/pt.json
@@ -577,6 +577,11 @@
       "password_protect_description": "Crie uma palavra-passe para a sua partilha. Qualquer pessoa que descarregue esta partilha necessitará desta palavra-passe para aceder à mesma. Nota: Após a criação, esta palavra-passe será encriptada e não será possível recuperá-la. Certifique-se de que a guarda num local seguro.",
       "remove_password": "Remover a palavra-passe"
     },
+    "diagnostics": {
+      "button": "Diagnostics",
+      "generating": "Collecting…",
+      "confirm": "Collect and download a diagnostic bundle? This may take a few seconds."
+    },
     "stats": {
       "downloads": {
         "all_time": "Downloads de todos os tempos",

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Middleware\AdminMiddleware as Admin;
 use App\Http\Middleware\NoUsersMiddleware as NoUsers;
 use App\Http\Controllers\SettingsController;
 use App\Http\Controllers\SharesController;
+use App\Http\Controllers\DiagnosticsController;
 use App\Http\Controllers\BackgroundsController;
 use App\Services\SettingsService;
 use App\Http\Controllers\ThemesController;
@@ -132,6 +133,12 @@ Route::group([], function ($router) {
 
         //prune expired shares
         Route::post('/prune-expired', [SharesController::class, 'pruneExpiredShares'])->name('shares.pruneExpired');
+    });
+
+    //diagnostics bundle [auth, admin]
+    Route::group(['prefix' => 'admin/diagnostics', 'middleware' => ['auth', Admin::class]], function () {
+        Route::post('/',               [DiagnosticsController::class, 'generate'])->name('diagnostics.generate');
+        Route::get('/{token}',         [DiagnosticsController::class, 'download'])->name('diagnostics.download');
     });
 
     //all shares [auth, admin]


### PR DESCRIPTION
Adds a diagnostics bundle feature for admins:
- DiagnosticsController generates an AES-256 encrypted ZIP containing system info, PHP config, queue status, share stats, and recent logs
- One-time download token (valid 60s) returned alongside the decryption key
- DiagnosticsModal displays the decryption key for the admin to save before the download completes
- Diagnostics button visible to admins in the settings header
- API routes: POST /api/admin/diagnostics, GET /api/admin/diagnostics/{token}

**A complete, ready-to-run container with these features built, is available for preview and testing here:**
~ghcr.io/rza-sf/erugo:0.2.15-2394df9~

**Update (2026-07-28): Incl. fix for https://github.com/ErugoOSS/Erugo/pull/265 
ghcr.io/rza-sf/erugo:0.2.15-421a556**

// RZA-SF //