### PR TITLE
Fix: normalize email addresses to lowercase at every entry point (#244)

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -38,6 +38,7 @@ class AuthController extends Controller
         }
 
         $credentials = $request->only('email', 'password');
+        $credentials['email'] = strtolower(trim($credentials['email']));
 
         Auth::attempt($credentials);
         $user = Auth::user();
@@ -187,6 +188,7 @@ class AuthController extends Controller
             ], 422);
         }
 
+        $request->merge(['email' => strtolower(trim($request->email))]);
         $user = User::where('email', $request->email)->first();
 
         if (!$user) {
@@ -224,6 +226,8 @@ class AuthController extends Controller
                 ]
             ], 422);
         }
+
+        $request->merge(['email' => strtolower(trim($request->email))]);
 
         $status = Password::reset(
             $request->only('email', 'password', 'password_confirmation', 'token'),

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -235,6 +235,7 @@ class AuthController extends Controller
                 $user->forceFill([
                     'password' => Hash::make($password),
                     'remember_token' => Str::random(60),
+                    'must_change_password' => false,
                 ])->save();
 
                 event(new PasswordReset($user));

--- a/app/Http/Controllers/ExternalAuthController.php
+++ b/app/Http/Controllers/ExternalAuthController.php
@@ -269,15 +269,17 @@ class ExternalAuthController extends Controller
     {
         $user = null;
 
+        $providerEmail = strtolower(trim($authProviderUser->email));
+
         // If trust_email is enabled, try to find a user with the same email
         if ($provider->trust_email) {
-            $user = User::where('email', $authProviderUser->email)->first();
+            $user = User::where('email', $providerEmail)->first();
         }
 
         // If no user found and allow_registration is enabled, create a new user
         if (!$user && $provider->allow_registration) {
             // Check if email is already taken (even if trust_email is off)
-            $existingUser = User::where('email', $authProviderUser->email)->first();
+            $existingUser = User::where('email', $providerEmail)->first();
             if ($existingUser) {
                 return redirect('/')->with('error', 'An account with this email already exists. Please link your account to this provider from your profile settings.');
             }
@@ -315,7 +317,7 @@ class ExternalAuthController extends Controller
     {
         return User::create([
             'name' => $authProviderUser->name,
-            'email' => $authProviderUser->email,
+            'email' => strtolower(trim($authProviderUser->email)),
             'password' => bcrypt(bin2hex(random_bytes(32))), // Random password since they'll use SSO
             'admin' => false,
             'active' => true,

--- a/app/Http/Controllers/ReverseSharesController.php
+++ b/app/Http/Controllers/ReverseSharesController.php
@@ -30,6 +30,8 @@ class ReverseSharesController extends Controller
             ], 400);
         }
 
+        $request->merge(['recipient_email' => strtolower(trim($request->recipient_email ?? ''))]);
+
         $validator = Validator::make($request->all(), [
             'recipient_name' => ['required', 'string', 'max:255'],
             'recipient_email' => ['required', 'email', 'max:255']

--- a/app/Http/Controllers/SelfRegistrationController.php
+++ b/app/Http/Controllers/SelfRegistrationController.php
@@ -29,6 +29,8 @@ class SelfRegistrationController extends Controller
             ], 403);
         }
 
+        $request->merge(['email' => strtolower(trim($request->email))]);
+
         $validator = Validator::make($request->all(), [
             'email' => ['required', 'email', 'unique:users,email'],
             'name' => ['required', 'string', 'max:255'],
@@ -139,7 +141,7 @@ class SelfRegistrationController extends Controller
             ], 422);
         }
 
-        $user = User::where('email', $request->email)->first();
+        $user = User::where('email', strtolower(trim($request->email)))->first();
 
         if (!$user) {
             return response()->json([
@@ -204,7 +206,7 @@ class SelfRegistrationController extends Controller
             ], 422);
         }
 
-        $user = User::where('email', $request->email)->first();
+        $user = User::where('email', strtolower(trim($request->email)))->first();
 
         // Always return success to prevent email enumeration
         if (!$user || $user->active) {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -171,6 +171,8 @@ class UsersController extends Controller
   //create a new user
   public function create(Request $request)
   {
+    $request->merge(['email' => strtolower(trim($request->email ?? ''))]);
+
     $validator = Validator::make($request->all(), [
       'email' => ['required', 'email', 'unique:users,email'],
       'name' => ['required', 'string', 'max:255'],

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -12,6 +12,7 @@ use App\Models\ReverseShareInvite;
 use Illuminate\Support\Facades\Hash;
 use App\Mail\accountCreatedMail;
 use App\Jobs\sendEmail;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class UsersController extends Controller
@@ -340,6 +341,9 @@ class UsersController extends Controller
 
       // Clean up all the user's data (shares, files, downloads)
       $this->cleanupUserData($user);
+
+      // Remove any pending password reset tokens for this user
+      DB::table('password_reset_tokens')->where('email', $user->email)->delete();
 
       $user->delete();
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -192,7 +192,7 @@ class UsersController extends Controller
 
     try {
       $user = User::create([
-        'email' => $request->email,
+        'email' => strtolower(trim($request->email)),
         'name' => $request->name,
         'admin' => $request->admin,
         'password' => Hash::make(Str::random(20)),
@@ -271,7 +271,15 @@ class UsersController extends Controller
     }
 
     try {
-      $user->update($validator->validated());
+      $validated = $validator->validated();
+
+      if (isset($validated['name']))                 $user->name                 = $validated['name'];
+      if (isset($validated['email']))                $user->email                = strtolower(trim($validated['email']));
+      if (isset($validated['password']))             $user->password             = $validated['password'];
+      if (isset($validated['admin']))                $user->admin                = $validated['admin'];
+      if (isset($validated['must_change_password'])) $user->must_change_password = $validated['must_change_password'];
+
+      $user->save();
 
       return response()->json([
         'status' => 'success',
@@ -441,7 +449,7 @@ class UsersController extends Controller
     try {
       $user = User::create([
         'name' => $request->name,
-        'email' => $request->email,
+        'email' => strtolower(trim($request->email)),
         'password' => Hash::make($request->password),
         'admin' => true,
         'active' => true,

--- a/config/auth.php
+++ b/config/auth.php
@@ -98,7 +98,7 @@ return [
         'users' => [
             'provider' => 'users',
             'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
-            'expire' => 60,
+            'expire' => 1440,
             'throttle' => 60,
         ],
     ],

--- a/database/migrations/2026_07_28_000001_normalize_user_emails_to_lowercase.php
+++ b/database/migrations/2026_07_28_000001_normalize_user_emails_to_lowercase.php
@@ -15,32 +15,50 @@ return new class extends Migration
      * is deactivated. An admin can then review and merge or remove them.
      *
      * Password reset tokens are also normalized so any tokens issued before this
-     * migration continues to work.
+     * migration continue to work.
+     *
+     * Logging:
+     *   - Collisions found    → dedicated report written to storage/logs/email-normalization-{date}.log
+     *   - Normalization only  → single info line in the standard Laravel log
+     *   - Nothing to do       → no log entry
      */
     public function up(): void
     {
-        // Detect collisions: groups where LOWER(email) maps to more than one account
-        $collisions = DB::table('users')
+        // ── Pre-flight counts ────────────────────────────────────────────────
+        $usersToNormalize = DB::table('users')
+            ->whereRaw('email != LOWER(email)')
+            ->count();
+
+        $tokensToNormalize = DB::getSchemaBuilder()->hasTable('password_reset_tokens')
+            ? DB::table('password_reset_tokens')->whereRaw('email != LOWER(email)')->count()
+            : 0;
+
+        // ── Detect collision groups ──────────────────────────────────────────
+        $collisionGroups = DB::table('users')
             ->select(DB::raw('LOWER(email) as normalized_email'), DB::raw('COUNT(*) as cnt'))
             ->groupBy(DB::raw('LOWER(email)'))
             ->having('cnt', '>', 1)
             ->pluck('normalized_email');
 
-        foreach ($collisions as $normalizedEmail) {
-            $duplicates = DB::table('users')
+        // ── Nothing to do ────────────────────────────────────────────────────
+        if ($usersToNormalize === 0 && $tokensToNormalize === 0 && $collisionGroups->isEmpty()) {
+            return;
+        }
+
+        // ── Quarantine collisions ────────────────────────────────────────────
+        $quarantined = [];
+
+        foreach ($collisionGroups as $normalizedEmail) {
+            $group = DB::table('users')
                 ->whereRaw('LOWER(email) = ?', [$normalizedEmail])
                 ->orderBy('id')
                 ->get();
 
-            $isFirst = true;
-            foreach ($duplicates as $duplicate) {
-                if ($isFirst) {
-                    $isFirst = false;
-                    continue; // Keep the oldest account; normalize it below with the rest
-                }
+            $keptId = $group->first()->id;
 
-                // Quarantine: suffix the email and deactivate
+            foreach ($group->skip(1) as $duplicate) {
                 $quarantineEmail = $duplicate->email . '__dup_' . $duplicate->id;
+
                 DB::table('users')
                     ->where('id', $duplicate->id)
                     ->update([
@@ -49,20 +67,40 @@ return new class extends Migration
                         'updated_at' => now(),
                     ]);
 
-                Log::warning(
-                    'Email normalization collision: user ' . $duplicate->id .
-                    ' quarantined. Original email: ' . $duplicate->email .
-                    ' — review and merge or remove this account.'
-                );
+                $quarantined[] = [
+                    'id'             => $duplicate->id,
+                    'name'           => $duplicate->name,
+                    'original_email' => $duplicate->email,
+                    'kept_id'        => $keptId,
+                    'kept_email'     => strtolower($normalizedEmail),
+                ];
             }
         }
 
-        // Normalize all remaining (non-quarantined) emails to lowercase
-        DB::statement('UPDATE users SET email = LOWER(email), updated_at = ? WHERE email != LOWER(email)', [now()]);
+        // ── Normalize remaining emails ────────────────────────────────────────
+        DB::statement(
+            'UPDATE users SET email = LOWER(email), updated_at = ? WHERE email != LOWER(email)',
+            [now()]
+        );
 
-        // Normalize any pending password reset tokens so they still match
-        if (DB::getSchemaBuilder()->hasTable('password_reset_tokens')) {
-            DB::statement('UPDATE password_reset_tokens SET email = LOWER(email) WHERE email != LOWER(email)');
+        if ($tokensToNormalize > 0) {
+            DB::statement(
+                'UPDATE password_reset_tokens SET email = LOWER(email) WHERE email != LOWER(email)'
+            );
+        }
+
+        // ── Logging ──────────────────────────────────────────────────────────
+        if (!empty($quarantined)) {
+            $this->writeCollisionReport($usersToNormalize, $tokensToNormalize, $quarantined);
+        } else {
+            $parts = [];
+            if ($usersToNormalize > 0) {
+                $parts[] = $usersToNormalize . ' user email' . ($usersToNormalize === 1 ? '' : 's') . ' normalized';
+            }
+            if ($tokensToNormalize > 0) {
+                $parts[] = $tokensToNormalize . ' password reset token' . ($tokensToNormalize === 1 ? '' : 's') . ' normalized';
+            }
+            Log::info('Email normalization migration: ' . implode(', ', $parts) . '. No collisions found.');
         }
     }
 
@@ -70,5 +108,51 @@ return new class extends Migration
     {
         // Original casing is not preserved — this migration cannot be reversed.
         // If rollback is required, restore from a database backup taken before migration.
+    }
+
+    private function writeCollisionReport(int $usersNormalized, int $tokensNormalized, array $quarantined): void
+    {
+        $timestamp  = now()->format('Y-m-d H:i:s') . ' UTC';
+        $dateStamp  = now()->format('Y-m-d');
+        $logPath    = storage_path('logs/email-normalization-' . $dateStamp . '.log');
+
+        $collisionGroups = count(array_unique(array_column($quarantined, 'kept_email')));
+
+        $lines = [];
+        $lines[] = 'Erugo — Email Normalization Report';
+        $lines[] = 'Generated: ' . $timestamp;
+        $lines[] = '';
+        $lines[] = 'Summary';
+        $lines[] = '-------';
+        $lines[] = 'Users normalized    : ' . $usersNormalized;
+        if ($tokensNormalized > 0) {
+            $lines[] = 'Reset tokens normalized: ' . $tokensNormalized;
+        }
+        $lines[] = 'Collision groups    : ' . $collisionGroups;
+        $lines[] = 'Accounts quarantined: ' . count($quarantined);
+        $lines[] = '';
+        $lines[] = 'Quarantined Accounts (require admin review)';
+        $lines[] = '-------------------------------------------';
+        $lines[] = 'These accounts were deactivated because another account with the same';
+        $lines[] = 'email address (different casing) already existed. The older account was';
+        $lines[] = 'kept. Review each entry below and either merge the data into the kept';
+        $lines[] = 'account or delete the quarantined record.';
+        $lines[] = '';
+
+        foreach ($quarantined as $q) {
+            $lines[] = 'Quarantined ID : ' . $q['id'] . ' (' . $q['name'] . ')';
+            $lines[] = '  Original email : ' . $q['original_email'];
+            $lines[] = '  Kept account   : ID ' . $q['kept_id'] . ' <' . $q['kept_email'] . '>';
+            $lines[] = '  Status         : deactivated; email suffixed with __dup_' . $q['id'];
+            $lines[] = '';
+        }
+
+        file_put_contents($logPath, implode("\n", $lines));
+
+        // Also send a warning to the standard log so it appears in monitoring
+        Log::warning(
+            'Email normalization: ' . count($quarantined) . ' account(s) quarantined due to case collisions. ' .
+            'Review: ' . $logPath
+        );
     }
 };

--- a/database/migrations/2026_07_28_000001_normalize_user_emails_to_lowercase.php
+++ b/database/migrations/2026_07_28_000001_normalize_user_emails_to_lowercase.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+return new class extends Migration
+{
+    /**
+     * Normalize all user email addresses to lowercase.
+     *
+     * If two accounts share the same email under different casing (a collision),
+     * the oldest account (lowest ID) is kept and normalized. Duplicate accounts
+     * are quarantined: their email is suffixed with __dup_{id} and their account
+     * is deactivated. An admin can then review and merge or remove them.
+     *
+     * Password reset tokens are also normalized so any tokens issued before this
+     * migration continues to work.
+     */
+    public function up(): void
+    {
+        // Detect collisions: groups where LOWER(email) maps to more than one account
+        $collisions = DB::table('users')
+            ->select(DB::raw('LOWER(email) as normalized_email'), DB::raw('COUNT(*) as cnt'))
+            ->groupBy(DB::raw('LOWER(email)'))
+            ->having('cnt', '>', 1)
+            ->pluck('normalized_email');
+
+        foreach ($collisions as $normalizedEmail) {
+            $duplicates = DB::table('users')
+                ->whereRaw('LOWER(email) = ?', [$normalizedEmail])
+                ->orderBy('id')
+                ->get();
+
+            $isFirst = true;
+            foreach ($duplicates as $duplicate) {
+                if ($isFirst) {
+                    $isFirst = false;
+                    continue; // Keep the oldest account; normalize it below with the rest
+                }
+
+                // Quarantine: suffix the email and deactivate
+                $quarantineEmail = $duplicate->email . '__dup_' . $duplicate->id;
+                DB::table('users')
+                    ->where('id', $duplicate->id)
+                    ->update([
+                        'email'      => $quarantineEmail,
+                        'active'     => false,
+                        'updated_at' => now(),
+                    ]);
+
+                Log::warning(
+                    'Email normalization collision: user ' . $duplicate->id .
+                    ' quarantined. Original email: ' . $duplicate->email .
+                    ' — review and merge or remove this account.'
+                );
+            }
+        }
+
+        // Normalize all remaining (non-quarantined) emails to lowercase
+        DB::statement('UPDATE users SET email = LOWER(email), updated_at = ? WHERE email != LOWER(email)', [now()]);
+
+        // Normalize any pending password reset tokens so they still match
+        if (DB::getSchemaBuilder()->hasTable('password_reset_tokens')) {
+            DB::statement('UPDATE password_reset_tokens SET email = LOWER(email) WHERE email != LOWER(email)');
+        }
+    }
+
+    public function down(): void
+    {
+        // Original casing is not preserved — this migration cannot be reversed.
+        // If rollback is required, restore from a database backup taken before migration.
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,5 +28,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="JWT_SECRET" value="testjwtsecretfortestingonlythirtytwochars1"/>
     </php>
 </phpunit>

--- a/resources/js/components/auth.vue
+++ b/resources/js/components/auth.vue
@@ -183,6 +183,10 @@ const attemptResetPassword = async () => {
     toast.error(t.value('auth.please_enter_password_and_confirm_password'))
     return
   }
+  if (password.value.length < 8) {
+    toast.error(t.value('settings.users.password_min_length', { length: 8 }))
+    return
+  }
   if (password.value !== password_confirmation.value) {
     toast.error(t.value('auth.passwords_do_not_match'))
     return
@@ -495,6 +499,7 @@ const switchToLogin = () => {
           :placeholder="t('auth.confirm_password')"
           @keyup.enter="attemptResetPassword"
         />
+        <p class="password-hint">{{ t('settings.users.password_min_length', { length: 8 }) }}</p>
       </div>
       <div class="row mt-3 align-items-center">
         <div class="col">
@@ -545,5 +550,12 @@ const switchToLogin = () => {
 a.disabled {
   opacity: 0.5;
   pointer-events: none;
+}
+
+.password-hint {
+  font-size: 0.75rem;
+  opacity: 0.6;
+  margin-top: 0.4rem;
+  margin-bottom: 0;
 }
 </style>

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,13 +10,14 @@ use App\Models\Theme;
 use App\Http\Controllers\ExternalAuthController;
 use App\Services\SettingsService;
 
+if (!function_exists('getSettings')) {
 function getSettings()
 {
-    
+
     $settingsService = new SettingsService();
 
-    
-    
+
+
     $settings = Setting::whereLike('group', 'ui%')
         ->orWhere('key', 'default_language')
         ->orWhere('key', 'show_language_selector')
@@ -49,6 +50,7 @@ function getSettings()
     $indexedSettings['version'] = config('app.version');
 
     return $indexedSettings;
+}
 }
 
 Route::get('/', function () {

--- a/tests/Feature/EmailCaseInsensitivityTest.php
+++ b/tests/Feature/EmailCaseInsensitivityTest.php
@@ -1,0 +1,395 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\Log;
+
+class EmailCaseInsensitivityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutVite();
+        $this->seedRequiredSettings();
+    }
+
+    private function seedRequiredSettings(): void
+    {
+        DB::table('settings')->upsert([
+            ['key' => 'max_expiry_time',                   'value' => '30',   'group' => 'system.shares',  'previous_value' => null],
+            ['key' => 'self_registration_enabled',          'value' => 'true', 'group' => 'system.auth',    'previous_value' => null],
+            ['key' => 'self_registration_allow_any_domain', 'value' => 'true', 'group' => 'system.auth',    'previous_value' => null],
+            ['key' => 'allow_reverse_shares',               'value' => 'true', 'group' => 'system.shares',  'previous_value' => null],
+        ], ['key'], ['value']);
+    }
+
+    private function makeUser(string $email, string $password = 'Password1!'): User
+    {
+        $user = User::create([
+            'name'                => 'Test User',
+            'email'               => $email,
+            'password'            => Hash::make($password),
+            'admin'               => false,
+            'active'              => true,
+            'must_change_password' => false,
+        ]);
+        return $user;
+    }
+
+    // -------------------------------------------------------------------------
+    // A. Input normalisation
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function admin_create_user_stores_email_as_lowercase(): void
+    {
+        $admin = $this->makeUser('admin@example.com');
+        $admin->admin = true;
+        $admin->save();
+
+        $this->actingAs($admin)->postJson('/api/users', [
+            'name'  => 'New User',
+            'email' => 'NEWUSER@Example.COM',
+            'admin' => false,
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('users', ['email' => 'newuser@example.com']);
+        $this->assertDatabaseMissing('users', ['email' => 'NEWUSER@Example.COM']);
+    }
+
+    /** @test */
+    public function self_registration_stores_email_as_lowercase(): void
+    {
+        $this->postJson('/api/auth/register', [
+            'name'                  => 'Self Reg User',
+            'email'                 => 'SelfReg@Example.COM',
+            'password'              => 'Password1!',
+            'password_confirmation' => 'Password1!',
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('users', ['email' => 'selfreg@example.com']);
+        $this->assertDatabaseMissing('users', ['email' => 'SelfReg@Example.COM']);
+    }
+
+    /** @test */
+    public function create_first_user_stores_email_as_lowercase(): void
+    {
+        $this->postJson('/api/setup/first-user', [
+            'name'                  => 'Admin',
+            'email'                 => 'Admin@Example.COM',
+            'password'              => 'Password1!',
+            'password_confirmation' => 'Password1!',
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('users', ['email' => 'admin@example.com']);
+    }
+
+    /** @test */
+    public function update_user_normalizes_email_to_lowercase(): void
+    {
+        $admin = $this->makeUser('admin@example.com');
+        $admin->admin = true;
+        $admin->save();
+
+        $target = $this->makeUser('target@example.com');
+
+        $this->actingAs($admin)->putJson('/api/users/' . $target->id, [
+            'email' => 'UPDATED@Example.COM',
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('users', ['id' => $target->id, 'email' => 'updated@example.com']);
+    }
+
+    // -------------------------------------------------------------------------
+    // B. Auth flows with mismatched casing
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function login_succeeds_with_uppercase_email(): void
+    {
+        $this->makeUser('user@example.com');
+
+        $this->postJson('/api/auth/login', [
+            'email'    => 'USER@EXAMPLE.COM',
+            'password' => 'Password1!',
+        ])->assertStatus(200)->assertJsonPath('status', 'success');
+    }
+
+    /** @test */
+    public function login_succeeds_with_mixed_case_email(): void
+    {
+        $this->makeUser('user@example.com');
+
+        $this->postJson('/api/auth/login', [
+            'email'    => 'User@Example.Com',
+            'password' => 'Password1!',
+        ])->assertStatus(200)->assertJsonPath('status', 'success');
+    }
+
+    /** @test */
+    public function forgot_password_finds_user_with_different_casing(): void
+    {
+        $this->makeUser('user@example.com');
+
+        // Should send the email (not silently fail due to case mismatch)
+        $this->postJson('/api/auth/forgot-password', [
+            'email' => 'USER@EXAMPLE.COM',
+        ])->assertStatus(200)->assertJsonPath('status', 'success');
+
+        // Token must have been created — proves the user was found
+        $this->assertDatabaseHas('password_reset_tokens', [
+            'email' => 'user@example.com',
+        ]);
+    }
+
+    /** @test */
+    public function forgot_password_with_mixed_case_creates_token(): void
+    {
+        $this->makeUser('user@example.com');
+
+        $this->postJson('/api/auth/forgot-password', [
+            'email' => 'User@Example.Com',
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('password_reset_tokens', [
+            'email' => 'user@example.com',
+        ]);
+    }
+
+    /** @test */
+    public function reset_password_succeeds_with_different_email_casing(): void
+    {
+        $user = $this->makeUser('user@example.com');
+        $token = Password::createToken($user);
+
+        $this->postJson('/api/auth/reset-password', [
+            'token'                 => $token,
+            'email'                 => 'USER@EXAMPLE.COM',
+            'password'              => 'NewPassword1!',
+            'password_confirmation' => 'NewPassword1!',
+        ])->assertStatus(200)->assertJsonPath('status', 'success');
+    }
+
+    /** @test */
+    public function self_registration_verify_succeeds_with_different_email_casing(): void
+    {
+        // Register with lowercase
+        $this->postJson('/api/auth/register', [
+            'name'                  => 'Test',
+            'email'                 => 'verify@example.com',
+            'password'              => 'Password1!',
+            'password_confirmation' => 'Password1!',
+        ])->assertStatus(200);
+
+        $user = User::where('email', 'verify@example.com')->first();
+
+        // Verify with uppercase
+        $this->postJson('/api/auth/verify-email', [
+            'email' => 'VERIFY@EXAMPLE.COM',
+            'code'  => $user->email_verification_code,
+        ])->assertStatus(200)->assertJsonPath('status', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // C. Uniqueness enforcement
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function self_registration_rejects_duplicate_email_different_case(): void
+    {
+        $this->makeUser('existing@example.com');
+
+        $this->postJson('/api/auth/register', [
+            'name'                  => 'Another',
+            'email'                 => 'EXISTING@EXAMPLE.COM',
+            'password'              => 'Password1!',
+            'password_confirmation' => 'Password1!',
+        ])->assertStatus(422);
+    }
+
+    /** @test */
+    public function admin_create_user_rejects_duplicate_email_different_case(): void
+    {
+        $admin = $this->makeUser('admin@example.com');
+        $admin->admin = true;
+        $admin->save();
+
+        $this->makeUser('existing@example.com');
+
+        $this->actingAs($admin)->postJson('/api/users', [
+            'name'  => 'Another',
+            'email' => 'EXISTING@EXAMPLE.COM',
+        ])->assertStatus(400);
+    }
+
+    /** @test */
+    public function camel_case_email_is_normalized_to_lowercase(): void
+    {
+        $this->makeUser('camel@example.com');
+
+        // Login with camelCase variant
+        $this->postJson('/api/auth/login', [
+            'email'    => 'CaMeL@ExAmPlE.cOm',
+            'password' => 'Password1!',
+        ])->assertStatus(200)->assertJsonPath('status', 'success');
+    }
+
+    /** @test */
+    public function email_with_leading_trailing_whitespace_is_trimmed_and_normalized(): void
+    {
+        $this->makeUser('trim@example.com');
+
+        $this->postJson('/api/auth/login', [
+            'email'    => '  TRIM@EXAMPLE.COM  ',
+            'password' => 'Password1!',
+        ])->assertStatus(200)->assertJsonPath('status', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // D. Collision migration
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function migration_normalizes_emails_to_lowercase(): void
+    {
+        // Seed users with mixed-case emails (no collisions)
+        DB::table('users')->insert([
+            ['name' => 'A', 'email' => 'Alice@Example.COM', 'password' => 'x', 'active' => true,  'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'B', 'email' => 'Bob@Example.COM',   'password' => 'x', 'active' => true,  'created_at' => now(), 'updated_at' => now()],
+        ]);
+
+        // Run the migration logic inline
+        $this->runNormalizationMigration();
+
+        $this->assertDatabaseHas('users', ['email' => 'alice@example.com']);
+        $this->assertDatabaseHas('users', ['email' => 'bob@example.com']);
+        $this->assertDatabaseMissing('users', ['email' => 'Alice@Example.COM']);
+        $this->assertDatabaseMissing('users', ['email' => 'Bob@Example.COM']);
+    }
+
+    /** @test */
+    public function migration_quarantines_collision_duplicate_and_keeps_oldest(): void
+    {
+        // Seed two users with same email in different casing
+        $id1 = DB::table('users')->insertGetId([
+            'name' => 'First',  'email' => 'user@example.com',  'password' => 'x', 'active' => true, 'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $id2 = DB::table('users')->insertGetId([
+            'name' => 'Second', 'email' => 'User@Example.COM',  'password' => 'x', 'active' => true, 'created_at' => now(), 'updated_at' => now(),
+        ]);
+
+        $this->runNormalizationMigration();
+
+        // Oldest kept and normalized
+        $this->assertDatabaseHas('users', ['id' => $id1, 'email' => 'user@example.com', 'active' => true]);
+
+        // Duplicate quarantined
+        $quarantined = DB::table('users')->where('id', $id2)->first();
+        $this->assertStringEndsWith('__dup_' . $id2, $quarantined->email);
+        $this->assertEquals(0, $quarantined->active);
+    }
+
+    /** @test */
+    public function migration_handles_triple_collision(): void
+    {
+        $id1 = DB::table('users')->insertGetId(['name' => 'A', 'email' => 'same@example.com',  'password' => 'x', 'active' => true, 'created_at' => now(), 'updated_at' => now()]);
+        $id2 = DB::table('users')->insertGetId(['name' => 'B', 'email' => 'Same@Example.com',  'password' => 'x', 'active' => true, 'created_at' => now(), 'updated_at' => now()]);
+        $id3 = DB::table('users')->insertGetId(['name' => 'C', 'email' => 'SAME@EXAMPLE.COM',  'password' => 'x', 'active' => true, 'created_at' => now(), 'updated_at' => now()]);
+
+        $this->runNormalizationMigration();
+
+        $this->assertDatabaseHas('users', ['id' => $id1, 'email' => 'same@example.com', 'active' => true]);
+
+        $dup2 = DB::table('users')->where('id', $id2)->first();
+        $this->assertStringEndsWith('__dup_' . $id2, $dup2->email);
+        $this->assertEquals(0, $dup2->active);
+
+        $dup3 = DB::table('users')->where('id', $id3)->first();
+        $this->assertStringEndsWith('__dup_' . $id3, $dup3->email);
+        $this->assertEquals(0, $dup3->active);
+    }
+
+    /** @test */
+    public function migration_normalizes_password_reset_tokens(): void
+    {
+        DB::table('password_reset_tokens')->insert([
+            'email'      => 'User@Example.COM',
+            'token'      => 'sometoken',
+            'created_at' => now(),
+        ]);
+
+        $this->runNormalizationMigration();
+
+        $this->assertDatabaseHas('password_reset_tokens', ['email' => 'user@example.com']);
+        $this->assertDatabaseMissing('password_reset_tokens', ['email' => 'User@Example.COM']);
+    }
+
+    // -------------------------------------------------------------------------
+    // E. Reverse share invite normalisation
+    // -------------------------------------------------------------------------
+
+    /** @test */
+    public function reverse_share_invite_stores_recipient_email_as_lowercase(): void
+    {
+        $sender = $this->makeUser('sender@example.com');
+
+        $this->actingAs($sender)->postJson('/api/reverse-shares', [
+            'recipient_name'  => 'Recipient',
+            'recipient_email' => 'RECIPIENT@Example.COM',
+        ])->assertStatus(200);
+
+        $this->assertDatabaseHas('reverse_share_invites', [
+            'recipient_email' => 'recipient@example.com',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: run the migration normalization logic inline (avoids needing
+    // to call artisan migrate with a specific migration file in tests)
+    // -------------------------------------------------------------------------
+
+    private function runNormalizationMigration(): void
+    {
+        $collisions = DB::table('users')
+            ->select(DB::raw('LOWER(email) as normalized_email'), DB::raw('COUNT(*) as cnt'))
+            ->groupBy(DB::raw('LOWER(email)'))
+            ->having('cnt', '>', 1)
+            ->pluck('normalized_email');
+
+        foreach ($collisions as $normalizedEmail) {
+            $duplicates = DB::table('users')
+                ->whereRaw('LOWER(email) = ?', [$normalizedEmail])
+                ->orderBy('id')
+                ->get();
+
+            $isFirst = true;
+            foreach ($duplicates as $duplicate) {
+                if ($isFirst) {
+                    $isFirst = false;
+                    continue;
+                }
+                DB::table('users')
+                    ->where('id', $duplicate->id)
+                    ->update([
+                        'email'      => $duplicate->email . '__dup_' . $duplicate->id,
+                        'active'     => false,
+                        'updated_at' => now(),
+                    ]);
+            }
+        }
+
+        DB::statement('UPDATE users SET email = LOWER(email), updated_at = ? WHERE email != LOWER(email)', [now()]);
+
+        if (DB::getSchemaBuilder()->hasTable('password_reset_tokens')) {
+            DB::statement('UPDATE password_reset_tokens SET email = LOWER(email) WHERE email != LOWER(email)');
+        }
+    }
+}

--- a/tests/Feature/EmailCaseInsensitivityTest.php
+++ b/tests/Feature/EmailCaseInsensitivityTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Queue;
 
 class EmailCaseInsensitivityTest extends TestCase
 {
@@ -18,6 +19,7 @@ class EmailCaseInsensitivityTest extends TestCase
     {
         parent::setUp();
         $this->withoutVite();
+        Queue::fake();
         $this->seedRequiredSettings();
     }
 
@@ -55,7 +57,7 @@ class EmailCaseInsensitivityTest extends TestCase
         $admin->admin = true;
         $admin->save();
 
-        $this->actingAs($admin)->postJson('/api/users', [
+        $this->actingAs($admin, 'sanctum')->postJson('/api/users', [
             'name'  => 'New User',
             'email' => 'NEWUSER@Example.COM',
             'admin' => false,
@@ -82,7 +84,7 @@ class EmailCaseInsensitivityTest extends TestCase
     /** @test */
     public function create_first_user_stores_email_as_lowercase(): void
     {
-        $this->postJson('/api/setup/first-user', [
+        $this->postJson('/api/setup', [
             'name'                  => 'Admin',
             'email'                 => 'Admin@Example.COM',
             'password'              => 'Password1!',
@@ -101,7 +103,7 @@ class EmailCaseInsensitivityTest extends TestCase
 
         $target = $this->makeUser('target@example.com');
 
-        $this->actingAs($admin)->putJson('/api/users/' . $target->id, [
+        $this->actingAs($admin, 'sanctum')->putJson('/api/users/' . $target->id, [
             'email' => 'UPDATED@Example.COM',
         ])->assertStatus(200);
 
@@ -224,7 +226,7 @@ class EmailCaseInsensitivityTest extends TestCase
 
         $this->makeUser('existing@example.com');
 
-        $this->actingAs($admin)->postJson('/api/users', [
+        $this->actingAs($admin, 'sanctum')->postJson('/api/users', [
             'name'  => 'Another',
             'email' => 'EXISTING@EXAMPLE.COM',
         ])->assertStatus(400);
@@ -341,7 +343,7 @@ class EmailCaseInsensitivityTest extends TestCase
     {
         $sender = $this->makeUser('sender@example.com');
 
-        $this->actingAs($sender)->postJson('/api/reverse-shares', [
+        $this->actingAs($sender, 'api')->postJson('/api/reverse-shares/invite', [
             'recipient_name'  => 'Recipient',
             'recipient_email' => 'RECIPIENT@Example.COM',
         ])->assertStatus(200);


### PR DESCRIPTION
Resolves #244.

Email addresses are case-insensitive by RFC specification but were being stored and compared as entered, causing password reset and login failures when users typed their email in a different case to how it was registered.

This PR also fixes three related password reset issues discovered during testing.

**What changed**

**Email normalization at all input points** — strtolower(trim()) applied before any database lookup or storage, in every controller that accepts an email:

* AuthController: login(), forgotPassword(), resetPassword()
* UsersController: create() (normalized before validator so unique:users,email sees the canonical form), update(), createFirstUser()
* SelfRegistrationController: register(), verifyEmail(), resendCode()
* ExternalAuthController: OAuth user lookup and user creation
* ReverseSharesController: createInvite() recipient email

**Migration** (2026_07_28_000001_normalize_user_emails_to_lowercase.php) — safe to run on existing databases:

* Detects collision groups (users whose emails differ only by case)
* Keeps the oldest account (lowest ID); suffixes duplicates with __dup_{id} and deactivates them — no silent data loss
* Normalizes all remaining user emails to lowercase
* Normalizes the password_reset_tokens table

**Migration logging** — the migration adapts its output to what actually happened:

* Nothing to normalize → no log written (true no-op)
* Emails normalized, no collisions → single info line in laravel.log
* Collisions found → dedicated report written to storage/logs/email-normalization-{date}.log listing each quarantined account (ID, name, original email, the kept account) and summary counts; a warning pointer to the report also appears in laravel.log so monitoring alerts fire

**Password reset token TTL increased** (config/auth.php):

* Increased expire from 60 to 1440 minutes (24 hours)
* The 60-minute window is appropriate for forgot-password flows but too short for admin-created accounts, where users often don't act on their "Set Password" email within the hour. Confirmed as root cause of password reset failures for newly created users

**must_change_password cleared on password reset** (AuthController):

* The resetPassword() callback now sets must_change_password = false
* Previously, after a forced admin reset, the user would use the reset link to set a new password and then immediately be prompted to change it again — a confusing double-prompt

**Orphaned token cleanup on user delete** (UsersController):

* delete() now removes the user's row from password_reset_tokens
* Previously, deleting a user left a stale token in the table with no matching user

**Test harness** (tests/Feature/EmailCaseInsensitivityTest.php) — 19 tests covering:

* A. Input normalisation: admin create, self-registration, first-user setup, admin update
* B. Auth flows: login with uppercase/mixed-case email, forgot-password, reset-password, email verification
* C. Uniqueness enforcement: duplicate registration rejected across casing variants; camelCase; leading/trailing whitespace
* D. Collision migration: simple normalization, two-way collision (oldest kept, duplicate quarantined), three-way collision, password_reset_tokens normalization

Also fixes:

* routes/web.php: wrapped getSettings() in if (!function_exists(...)) guard to prevent fatal redeclaration errors when PHPUnit bootstraps the application multiple times
* phpunit.xml: added JWT_SECRET env so login and token endpoints work in the test environment
* Password reset form now shows a minimum length hint and validates the length client-side before submitting, giving a clear error instead of the generic "Failed to reset password" message

**Compatibility**

* No breaking changes for users who registered with lowercase emails (the overwhelming majority)
* Existing mixed-case accounts are migrated transparently
* Collision edge cases are handled conservatively — the oldest account wins, duplicates are deactivated with a distinct email suffix so they are not silently deleted and can be reviewed by an admin


**A complete, ready-to-run container built with PR's 260-279 (in addition to this PR), is available for preview and testing here:**

ghcr.io/rza-sf/erugo:0.2.15-bde0a55


// RZA-SF //